### PR TITLE
Upgraded to loader 0.4.0/19w14b and fixed affix naming issue

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -4,10 +4,10 @@ ext {
 	version = "0.0.4+19w14a"
 	snapshot = true
 
-	minecraft = "19w14a";
-	mappings = "19w14a.3";
-	loader = "0.3.7.109";
-	fabricMod = "0.2.6.117";
+	minecraft = "19w14b";
+	mappings = "19w14b.4";
+	loader = "0.4.0+build.115";
+	fabricMod = "0.2.6.121";
 	cotton = "0.3.0+19w13b-SNAPSHOT"
 	silkMod = null
 	jankson = "1.1.0" //If needsShadow is false, jankson will not be included!

--- a/project.gradle
+++ b/project.gradle
@@ -1,14 +1,14 @@
 ext {
 	projectName = "cotton-resources"
 	group = "io.github.cottonmc"
-	version = "0.0.4+19w14a"
+	version = "0.0.4+19w14b"
 	snapshot = true
 
 	minecraft = "19w14b";
 	mappings = "19w14b.4";
 	loader = "0.4.0+build.115";
 	fabricMod = "0.2.6.121";
-	cotton = "0.3.0+19w13b-SNAPSHOT"
+	cotton = "0.5.0+19w14b-SNAPSHOT"
 	silkMod = null
 	jankson = "1.1.0" //If needsShadow is false, jankson will not be included!
 

--- a/src/main/java/io/github/cottonmc/resources/ResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/ResourceType.java
@@ -20,10 +20,10 @@ public interface ResourceType {
     /**
      *
      * Returns the full name of the block/item for the given affix. For example, given "ore", returns "copper_ore",
-     * if this is a copper resource.
+     * if this is a copper resource. If the affix is empty, only the base resource name is returned.
      */
     default String getFullNameForAffix(String affix) {
-        return getBaseResource() + "_" + affix;
+        return affix.equals("") ? getBaseResource() : getBaseResource() + "_" + affix;
     }
 
     /** 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,12 +1,20 @@
 {
+  "schemaVersion": 1,
   "id": "cotton-resources",
-  "name": "Cotton Resources",
   "version": "0.0.3",
-  "side": "universal",
-  "initializers": [
-    "io.github.cottonmc.resources.CottonResources"
+  "name": "Cotton Resources",
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "io.github.cottonmc.resources.CottonResources"
+    ]
+  },
+  "mixins": [
+    "cotton.common.json"
   ],
-  "mixins": {
-    "common": "cotton.common.json"
+
+  "requires": {
+    "fabricloader": ">=0.4.0",
+    "fabric": "*"
   }
 }


### PR DESCRIPTION
Upgraded to loader 0.4.0 and 19w14b.

Resource names were returning with an empty "_" character at the end if their affixes were empty. Fixed by adding a check for an empty affix. 