### PR TITLE
Update to 1.15.2 and start deprecating singular tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.2.4-SNAPSHOT'
+    id 'fabric-loom' version '0.2.6-SNAPSHOT'
     id 'maven-publish'
     id 'com.jfrog.artifactory' version '4.9.0'
 }
@@ -15,18 +15,19 @@ repositories {
     mavenLocal();
     maven { url "http://server.bbkr.space:8081/artifactory/libs-release/" }
     maven { url "https://minecraft.curseforge.com/api/maven" } //resolves REI
+    maven { url "https://dl.bintray.com/shedaniel/autoconfig1u/" }
 }
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings "net.fabricmc:yarn:${yarn_mappings}"
+    mappings "net.fabricmc:yarn:${minecraft_version}+${yarn_build}:v2"
     modApi "net.fabricmc:fabric-loader:${loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 
     modCompile "io.github.cottonmc:Jankson:${jankson_version}"
     include "io.github.cottonmc:Jankson:${jankson_version}"
 
-    modImplementation ("me.shedaniel:RoughlyEnoughItems:3.0-pre+build.1") {
+    modImplementation ("me.shedaniel:RoughlyEnoughItems:${rei_version}") {
         exclude(group: "blue.endless", module: "jankson")
         exclude(group: "io.github.prospector.modmenu", module: "ModMenu")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,17 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version=1.14.4
-yarn_mappings=1.14.4+build.2
-loader_version=0.4.8+build.157
+minecraft_version=1.15.2
+yarn_build=build.11
+loader_version=0.7.6+build.181
 
 # Mod Properties
-mod_version=1.4.1+1.14.4
+mod_version=1.5.0+1.15.2
 maven_group=io.github.cottonmc
 archives_base_name=cotton-resources
 
 # Dependencies
-fabric_version=0.3.0+build.200
+fabric_version=0.4.29+build.290-1.15
 jankson_version=1.0.0+j1.1.2
+
+rei_version=3.3.18

--- a/src/main/java/io/github/cottonmc/resources/BlockSuppliers.java
+++ b/src/main/java/io/github/cottonmc/resources/BlockSuppliers.java
@@ -8,31 +8,62 @@ import net.minecraft.block.Material;
 
 import java.util.function.Supplier;
 
+/**
+ * Contains all Suppliers used to create the block types used by Cotton-Resources.
+ */
 public class BlockSuppliers {
-    /** A generic metal ore supplier, similar to the properties of coal or iron ore. */
+    /**
+     * A generic metal ore supplier, similar to the properties of coal or iron ore.
+     */
     public static final Supplier<Block> STONE_TIER_ORE = () -> new LayeredOreBlock(FabricBlockSettings.of(Material.STONE)
             .hardness(3.0f)
             .resistance(3.0f)
             .build());
-    /** A resilient metal ore supplier, similar to the properties of redstone ore. */
-    public static final Supplier<Block> IRON_TIER_ORE = () -> new LayeredOreBlock(FabricBlockSettings.copy(Blocks.REDSTONE_ORE)
+    /**
+     * A resilient metal ore supplier, requires an iron like tool level to collect.
+     */
+    public static final Supplier<Block> IRON_TIER_ORE = () -> new LayeredOreBlock(FabricBlockSettings.copy(Blocks.DIAMOND_ORE)
             .hardness(3.0f)
             .resistance(3.0f)
-            //.breakByTool(FabricToolTags.PICKAXES, 2)
+            .breakByTool(FabricToolTags.PICKAXES, 2)
             .build());
-    /** An extremely resilient metal ore supplier, only harvestable by diamond or better pickaxes. */
+    /**
+     * A resilient metal ore supplier, similar to the properties of redstone ore where it has a glowing state.
+     *
+     * <p>May be used in future for other ores.</p>
+     */
+    public static final Supplier<Block> LIGHTABLE_IRON_TIER_ORE = () -> new LayeredOreBlock(FabricBlockSettings.copy(Blocks.REDSTONE_ORE)
+            .hardness(3.0f)
+            .resistance(3.0f)
+            .breakByTool(FabricToolTags.PICKAXES, 2)
+            .build());
+    /**
+     * An extremely resilient metal ore supplier, only harvestable by diamond or better pickaxes.
+     */
     public static final Supplier<Block> DIAMOND_TIER_ORE = () -> new LayeredOreBlock(FabricBlockSettings.of(Material.STONE)
             .hardness(3.0f)
             .resistance(3.0f)
             .breakByTool(FabricToolTags.PICKAXES, 3)
             .build());
-    /** A generic metal block supplier, based on the properties from iron_block */
+    /**
+     * An extremely resilient metal ore supplier, only harvestable by diamond or better pickaxes.
+     */
+    public static final Supplier<Block> RADIOACTIVE_DIAMOND_TIER_ORE = () -> new GlowingLayeredOreBlock(FabricBlockSettings.copy(Blocks.REDSTONE_ORE)
+            .hardness(3.0f)
+            .resistance(3.0f)
+            .breakByTool(FabricToolTags.PICKAXES, 3)
+            .build());
+    /**
+     * A generic metal block supplier, based on the properties from iron_block
+     */
     public static final Supplier<Block> METAL_BLOCK = () -> new Block(FabricBlockSettings.of(Material.METAL)
     		.sounds(CottonResources.METAL_SOUND_GROUP)
             .hardness(5.0f)
             .resistance(6.0f)
             .build());
-    /** A block supplier based on coal_block. */
+    /**
+     * A block supplier based on coal_block.
+     */
     public static final Supplier<Block> COAL_BLOCK = () -> new Block(FabricBlockSettings.of(Material.STONE)
             .hardness(5.0f)
             .resistance(6.0f)

--- a/src/main/java/io/github/cottonmc/resources/BuiltinResources.java
+++ b/src/main/java/io/github/cottonmc/resources/BuiltinResources.java
@@ -1,0 +1,114 @@
+package io.github.cottonmc.resources;
+
+import io.github.cottonmc.resources.type.GemResourceType;
+import io.github.cottonmc.resources.type.GenericResourceType;
+import io.github.cottonmc.resources.type.MetalResourceType;
+import io.github.cottonmc.resources.type.RadioactiveResourceType;
+import io.github.cottonmc.resources.type.ResourceType;
+
+/**
+ * An enumeration of all Built-in resources provided by Cotton-Resources.
+ */
+public final class BuiltinResources {
+	public static final MetalResourceType COPPER = ResourceTemplates.fullMetalType("copper").oreSupplier(BlockSuppliers.STONE_TIER_ORE).build();
+	public static final MetalResourceType SILVER = ResourceTemplates.fullMetalType("silver").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType LEAD = ResourceTemplates.fullMetalType("lead").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType ZINC = ResourceTemplates.fullMetalType("zinc").oreSupplier(BlockSuppliers.STONE_TIER_ORE).build();
+	public static final MetalResourceType ALUMINUM = ResourceTemplates.fullMetalType("aluminum").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType COBALT = ResourceTemplates.fullMetalType("cobalt").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+
+	public static final MetalResourceType TIN = ResourceTemplates.fullMetalType("tin").oreSupplier(BlockSuppliers.STONE_TIER_ORE).build();
+	public static final MetalResourceType TITANIUM = ResourceTemplates.fullMetalType("titanium").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType TUNGSTEN = ResourceTemplates.fullMetalType("tungsten").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+
+	public static final MetalResourceType PLATINUM = ResourceTemplates.fullMetalType("platinum").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType PALLADIUM = ResourceTemplates.fullMetalType("palladium").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType OSMIUM = ResourceTemplates.fullMetalType("osmium").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final MetalResourceType IRIDIUM = ResourceTemplates.fullMetalType("iridium").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+
+	public static final MetalResourceType STEEL = ResourceTemplates.metalTypeNoOre("steel").build();
+	public static final MetalResourceType BRASS = ResourceTemplates.metalTypeNoOre("brass").build();
+	public static final MetalResourceType ELECTRUM = ResourceTemplates.metalTypeNoOre("electrum").build();
+
+	public static final GenericResourceType COAL = ResourceType.builder("coal")
+		.generic()
+		.noBlock()
+		.withDustAffix()
+		.build();
+
+	public static final GenericResourceType COAL_COKE = ResourceType.builder("coal_coke")
+		.generic()
+		.blockSupplier(BlockSuppliers.COAL_BLOCK)
+		.withAffix("")
+		.build();
+
+	public static final GenericResourceType MERCURY = ResourceType.builder("mercury")
+		.generic()
+		.noBlock()
+		.withAffix("")
+		.build();
+
+	public static final RadioactiveResourceType URANIUM = ResourceTemplates.radioactiveTypeNoOre("uranium")
+		.allOres()
+		.itemAffixName("ingot")
+		.oreSupplier(BlockSuppliers.RADIOACTIVE_DIAMOND_TIER_ORE)
+		.build();
+
+	public static final RadioactiveResourceType THORIUM = ResourceTemplates.radioactiveTypeNoOre("thorium")
+		.itemAffixName("ingot")
+		.build();
+
+	public static final RadioactiveResourceType PLUTONIUM = ResourceTemplates.radioactiveTypeNoOre("plutonium")
+		.itemAffixName("ingot")
+		.build();
+
+	public static final GemResourceType RUBY = ResourceTemplates.fullGemType("ruby").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final GemResourceType TOPAZ = ResourceTemplates.fullGemType("topaz").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final GemResourceType AMETHYST = ResourceTemplates.fullGemType("amethyst").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final GemResourceType PERIDOT = ResourceTemplates.fullGemType("peridot").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+	public static final GemResourceType SAPPHIRE = ResourceTemplates.fullGemType("sapphire").oreSupplier(BlockSuppliers.IRON_TIER_ORE).build();
+
+	// Vanilla Resource Types
+	// These exist solely to add the gears/plates/dust when applicable.
+
+	public static final GenericResourceType WOOD = ResourceType.builder("wood")
+		.generic()
+		.noBlock()
+		.withGearAffix()
+		.build();
+
+	public static final GenericResourceType STONE = ResourceType.builder("stone")
+		.generic()
+		.noBlock()
+		.withGearAffix()
+		.build();
+
+	public static final GenericResourceType IRON = ResourceType.builder("iron")
+		.generic()
+		.noBlock()
+		.withDustAffix()
+		.withMachineAffixes()
+		.build();
+
+	public static final GenericResourceType GOLD = ResourceType.builder("gold")
+		.generic()
+		.noBlock()
+		.withDustAffix()
+		.withMachineAffixes()
+		.build();
+
+	public static final GenericResourceType DIAMOND = ResourceType.builder("diamond")
+		.generic()
+		.noBlock()
+		.withDustAffix()
+		.withMachineAffixes()
+		.build();
+
+	public static final GenericResourceType EMERALD = ResourceType.builder("emerald")
+		.generic()
+		.noBlock()
+		.withDustAffix()
+		.withMachineAffixes()
+		.build();
+
+}

--- a/src/main/java/io/github/cottonmc/resources/CottonResources.java
+++ b/src/main/java/io/github/cottonmc/resources/CottonResources.java
@@ -1,7 +1,23 @@
 package io.github.cottonmc.resources;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import blue.endless.jankson.Jankson;
+import blue.endless.jankson.JsonElement;
+import blue.endless.jankson.JsonGrammar;
+import blue.endless.jankson.JsonObject;
+import blue.endless.jankson.impl.SyntaxError;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
 import io.github.cottonmc.jankson.JanksonFactory;
 import io.github.cottonmc.resources.command.StripCommand;
+import io.github.cottonmc.resources.command.TagTestCommand;
 import io.github.cottonmc.resources.config.CottonResourcesConfig;
 import io.github.cottonmc.resources.oregen.BiomeSpec;
 import io.github.cottonmc.resources.oregen.CottonOreFeature;
@@ -36,26 +52,8 @@ import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.decorator.Decorator;
 import net.minecraft.world.gen.decorator.RangeDecoratorConfig;
 import net.minecraft.world.gen.feature.FeatureConfig;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import com.mojang.brigadier.tree.LiteralCommandNode;
-
-import blue.endless.jankson.Jankson;
-import blue.endless.jankson.JsonElement;
-import blue.endless.jankson.JsonGrammar;
-import blue.endless.jankson.JsonObject;
-import blue.endless.jankson.impl.SyntaxError;
 
 public class CottonResources implements ModInitializer {
 	public static final String COMMON = "c";
@@ -63,87 +61,105 @@ public class CottonResources implements ModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("CottonResources", new PrefixMessageFactory("CottonResources"));
 	public static CottonResourcesConfig CONFIG = new CottonResourcesConfig(); //ConfigManager.loadConfig(CottonResourcesConfig.class);
 	private static final String[] MACHINE_AFFIXES = new String[]{"gear", "plate"};
+	/**
+	 * @deprecated Please use the values in {@link BuiltinResources} instead to obtain the resource types.
+	 *
+	 * This will be made private in a few versions.
+	 */
 	public static final Map<String, ResourceType> BUILTINS = new HashMap<>();
-	
-	public static ItemGroup ITEM_GROUP = FabricItemGroupBuilder.build(new Identifier(MODID, "resources"), ()->new ItemStack(BUILTINS.get("copper").getItem("gear")));
-	
+
+	public static ItemGroup ITEM_GROUP = FabricItemGroupBuilder.build(new Identifier(MODID, "resources"), () -> new ItemStack(BuiltinResources.COPPER.getGear().orElseThrow(IllegalStateException::new)));
+
 	public static SoundEvent METAL_STEP_SOUND;
 	public static BlockSoundGroup METAL_SOUND_GROUP;
-	
+
 	@Override
 	public void onInitialize() {
-		
-		
-		METAL_STEP_SOUND = (SoundEvent)Registry.register(Registry.SOUND_EVENT, "block.cotton-resources.metal.step", new SoundEvent(new Identifier("c:block.cotton-resources.metal.step")));
+		METAL_STEP_SOUND = Registry.register(Registry.SOUND_EVENT, "block.cotton-resources.metal.step", new SoundEvent(new Identifier("c:block.cotton-resources.metal.step")));
 		METAL_SOUND_GROUP = new BlockSoundGroup(1.0F, 1.5F, SoundEvents.BLOCK_METAL_BREAK, METAL_STEP_SOUND, SoundEvents.BLOCK_METAL_PLACE, SoundEvents.BLOCK_METAL_HIT, SoundEvents.BLOCK_METAL_FALL);
-		
-		builtinMetal("copper", BlockSuppliers.STONE_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("silver", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("lead", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("zinc", BlockSuppliers.STONE_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("aluminum", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		MetalResourceType cobalt = builtinMetal("cobalt", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		//cobalt.withBlockAffix("nether_ore", BlockSuppliers.IRON_TIER_ORE);
-		
-		builtinMetal("tin", BlockSuppliers.STONE_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("titanium", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("tungsten", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
 
-		builtinMetal("platinum", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("palladium", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("osmium", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinMetal("iridium", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
+		BUILTINS.put("copper", BuiltinResources.COPPER);
+		BUILTINS.put("silver", BuiltinResources.SILVER);
+		BUILTINS.put("lead", BuiltinResources.LEAD);
+		BUILTINS.put("zinc", BuiltinResources.ZINC);
+		BUILTINS.put("aluminum", BuiltinResources.ALUMINUM);
+		BUILTINS.put("cobalt", BuiltinResources.COBALT);
 
-		builtinMetal("steel", null, MACHINE_AFFIXES);
-		builtinMetal("brass", null, MACHINE_AFFIXES);
-		builtinMetal("electrum", null, MACHINE_AFFIXES);
+		BUILTINS.put("tin", BuiltinResources.TIN);
+		BUILTINS.put("titanium", BuiltinResources.TITANIUM);
+		BUILTINS.put("tungsten", BuiltinResources.TUNGSTEN);
 
-		builtinItem("coal", "dust");
-		BUILTINS.put("coal_coke", new GenericResourceType("coal_coke").withBlockAffix("block", BlockSuppliers.COAL_BLOCK).withItemAffixes(""));
-		builtinItem("mercury");
+		BUILTINS.put("platinum", BuiltinResources.PLATINUM);
+		BUILTINS.put("palladium", BuiltinResources.PALLADIUM);
+		BUILTINS.put("osmium", BuiltinResources.OSMIUM);
+		BUILTINS.put("iridium", BuiltinResources.IRIDIUM);
 
-		builtinItem("wood", "gear");
-		builtinItem("stone", "gear");
-		builtinItem("iron", "gear", "plate", "dust");
-		builtinItem("gold", "gear", "plate", "dust");
+		BUILTINS.put("steel", BuiltinResources.STEEL);
+		BUILTINS.put("brass", BuiltinResources.BRASS);
+		BUILTINS.put("electrum", BuiltinResources.ELECTRUM);
 
-		//These might get rods or molten capsules. They'd just need to be added to the end.
-		RadioactiveResourceType uranium = builtinRadioactive("uranium", null, "gear", "plate", "ingot", "nugget");
-		uranium.withBlockAffix("ore", BlockSuppliers.DIAMOND_TIER_ORE);
-		uranium.withBlockAffix("nether_ore", BlockSuppliers.DIAMOND_TIER_ORE);
-		uranium.withBlockAffix("end_ore", BlockSuppliers.DIAMOND_TIER_ORE);
-		builtinRadioactive("plutonium", null, "gear", "plate", "ingot", "nugget");
-		builtinRadioactive("thorium", null, "gear", "plate", "ingot", "nugget");
+		BUILTINS.put("coal", BuiltinResources.COAL);
+		BUILTINS.put("coal_coke", BuiltinResources.COAL_COKE);
+		BUILTINS.put("mercury", BuiltinResources.MERCURY);
 
-		builtinItem("diamond", "gear", "plate", "dust");
-		builtinItem("emerald", "gear", "plate", "dust");
+		BUILTINS.put("wood", BuiltinResources.WOOD);
+		BUILTINS.put("stone", BuiltinResources.STONE);
+		BUILTINS.put("iron", BuiltinResources.IRON);
+		BUILTINS.put("gold", BuiltinResources.GOLD);
+		BUILTINS.put("diamond", BuiltinResources.DIAMOND);
+		BUILTINS.put("emerald", BuiltinResources.EMERALD);
 
-		builtinGem("ruby", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinGem("topaz", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinGem("amethyst", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinGem("peridot", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
-		builtinGem("sapphire", BlockSuppliers.IRON_TIER_ORE, MACHINE_AFFIXES);
+		//These might get rods or molten capsules. They'd just need to be added to the RadioactiveResourceType builder and their templates edited slightly.
+		BUILTINS.put("uranium", BuiltinResources.URANIUM);
+		BUILTINS.put("thorium", BuiltinResources.THORIUM);
+		BUILTINS.put("plutonium", BuiltinResources.PLUTONIUM);
+
+		BUILTINS.put("ruby", BuiltinResources.RUBY);
+		BUILTINS.put("topaz", BuiltinResources.TOPAZ);
+		BUILTINS.put("amethyst", BuiltinResources.AMETHYST);
+		BUILTINS.put("peridot", BuiltinResources.PERIDOT);
+		BUILTINS.put("sapphire", BuiltinResources.SAPPHIRE);
 
 		for (ResourceType resource : BUILTINS.values()) {
 			resource.registerAll();
 		}
-		
+
 		setupBiomeGenerators(); //add cotton-resources ores to all current biomes
-		RegistryEntryAddedCallback.event(Registry.BIOME).register((id, ident, biome)->setupBiomeGenerator(biome)); //Add cotton-resources ores to any later biomes that appear
-		
-		ResourceManagerHelper.get(net.minecraft.resource.ResourceType.SERVER_DATA).registerReloadListener(new OregenResourceListener());
+		RegistryEntryAddedCallback.event(Registry.BIOME).register((id, ident, biome) -> setupBiomeGenerator(biome)); //Add cotton-resources ores to any later biomes that appear
+
+		// THIS MUST BE WORLD TAGS, THEN OREGEN LISTENER OR DIMENSION AND BIOME SPECS SHALL FAIL GLORIOUSLY.
 		ResourceManagerHelper.get(net.minecraft.resource.ResourceType.SERVER_DATA).registerReloadListener(new WorldTagReloadListener());
-		
-		CommandRegistry.INSTANCE.register(false, (dispatcher)->{
+		ResourceManagerHelper.get(net.minecraft.resource.ResourceType.SERVER_DATA).registerReloadListener(new OregenResourceListener());
+
+		CommandRegistry.INSTANCE.register(false, (dispatcher) -> {
+			RootCommandNode<ServerCommandSource> rootCommandNode = dispatcher.getRoot();
+
 			LiteralCommandNode<ServerCommandSource> stripCommandNode = CommandManager.literal("strip")
-					.executes(new StripCommand())
-					.requires((source)->source.hasPermissionLevel(3))
-					.build();
-			
-			dispatcher.getRoot().addChild(stripCommandNode);
+				.executes(new StripCommand())
+				.requires((source) -> source.hasPermissionLevel(3))
+				.build();
+
+			rootCommandNode.addChild(stripCommandNode);
+
+			LiteralCommandNode<ServerCommandSource> tags = CommandManager.literal("taginfo").build();
+
+			LiteralCommandNode<ServerCommandSource> dimensions = CommandManager.literal("dimensions")
+				.requires(s -> s.hasPermissionLevel(3))
+				.executes(TagTestCommand::dimensions)
+				.build();
+
+			LiteralCommandNode<ServerCommandSource> biomes = CommandManager.literal("biomes")
+				.requires(s -> s.hasPermissionLevel(3))
+				.executes(TagTestCommand::biomes)
+				.build();
+
+			tags.addChild(dimensions);
+			tags.addChild(biomes);
+
+			rootCommandNode.addChild(tags);
 		});
-		
-		File file = new File(FabricLoader.getInstance().getConfigDirectory(),"CottonResources.json5");
+
+		File file = new File(FabricLoader.getInstance().getConfigDirectory(), "CottonResources.json5");
 		if (file.exists()) {
 			CONFIG = loadConfig();
 			saveConfig(CONFIG);
@@ -151,124 +167,77 @@ public class CottonResources implements ModInitializer {
 			saveConfig(CONFIG);
 		}
 	}
-	
+
 	private static void setupBiomeGenerators() {
 		for (Biome biome : Registry.BIOME) {
 			setupBiomeGenerator(biome);
 		}
 	}
-	
+
 	private static void setupBiomeGenerator(Biome biome) {
 		biome.addFeature(GenerationStep.Feature.UNDERGROUND_ORES,
-			Biome.configureFeature(
-				CottonOreFeature.COTTON_ORE,
-				FeatureConfig.DEFAULT,
-				Decorator.COUNT_RANGE,
-				new RangeDecoratorConfig(1, 0, 0, 256)
-			)
-		);
+			CottonOreFeature.COTTON_ORE
+				.configure(FeatureConfig.DEFAULT)
+				.createDecoratedFeature(
+					Decorator.COUNT_RANGE.configure(new RangeDecoratorConfig(1, 0, 0, 256)
+					)
+				));
 	}
 
-	private static MetalResourceType builtinMetal(String id, Supplier<Block> oreSupplier, String... extraAffixes) {
-		MetalResourceType result = new MetalResourceType(id);
-		if (oreSupplier != null) {
-			result.withOreSupplier(oreSupplier);
-			result.withBlockAffix("nether_ore", oreSupplier);
-			result.withBlockAffix("end_ore", oreSupplier);
-		}
-
-		if (extraAffixes.length > 0) {
-			result.withItemAffixes(extraAffixes);
-		}
-
-		BUILTINS.put(id, result);
-		return result;
-	}
-
-	private static void builtinGem(String id, Supplier<Block> oreSupplier, String... extraAffixes) {
-		GemResourceType result = new GemResourceType(id).withOreSupplier(oreSupplier);
-		if (extraAffixes.length > 0) {
-			result.withItemAffixes(extraAffixes);
-		}
-
-		BUILTINS.put(id, result);
-	}
-
-	private static RadioactiveResourceType builtinRadioactive(String id, Supplier<Block> oreSupplier, String... extraAffixes) {
-		RadioactiveResourceType result = new RadioactiveResourceType(id);
-		if (oreSupplier != null) result.withOreSupplier(oreSupplier);
-
-		if (extraAffixes.length > 0) {
-			result.withItemAffixes(extraAffixes);
-		}
-
-		BUILTINS.put(id, result);
-		return result;
-	}
-
-	private static void builtinItem(String id, String... extraAffixes) {
-		GenericResourceType result = new GenericResourceType(id).withItemAffixes(extraAffixes);
-		if (extraAffixes.length == 0) {
-			result.withItemAffixes(""); //This is just a base type with no affixes, like "mercury".
-		}
-		BUILTINS.put(id, result);
-	}
-	
-	
 	public static CottonResourcesConfig loadConfig() {
-		File file = new File(FabricLoader.getInstance().getConfigDirectory(),"CottonResources.json5");
-		
+		File file = new File(FabricLoader.getInstance().getConfigDirectory(), "CottonResources.json5");
+
 		Jankson jankson = JanksonFactory.builder()
-				.registerTypeAdapter(OreGenerationSettings.class, OreGenerationSettings::deserialize)
-				.build();
+			.registerTypeAdapter(OreGenerationSettings.class, OreGenerationSettings::deserialize)
+			.build();
 		try {
 			JsonObject json = jankson.load(file);
-			System.out.println("Loading: "+json);
+			CottonResources.LOGGER.info("Loading: " + json);
 			CottonResourcesConfig loading = jankson.fromJson(json, CottonResourcesConfig.class);
-			System.out.println("Loaded Map: "+loading.generators);
+			CottonResources.LOGGER.info("Loaded Map: " + loading.generators);
 			//Manually reload oregen because BiomeSpec and DimensionSpec can be fussy
-			
+
 			JsonObject oregen = json.getObject("generators");
-			if (oregen!=null) {
-				System.out.println("RELOADING "+oregen.size()+" entries");
-				for(Map.Entry<String, JsonElement> entry : oregen.entrySet()) {
+			if (oregen != null) {
+				CottonResources.LOGGER.info("RELOADING " + oregen.size() + " entries");
+				for (Map.Entry<String, JsonElement> entry : oregen.entrySet()) {
 					if (entry.getValue() instanceof JsonObject) {
-						OreGenerationSettings settings = OreGenerationSettings.deserialize((JsonObject)entry.getValue());
+						OreGenerationSettings settings = OreGenerationSettings.deserialize((JsonObject) entry.getValue());
 						loading.generators.put(entry.getKey(), settings);
 					}
 				}
 			}
-			
-			System.out.println("RELOADED Map: "+loading.generators);
-			
+
+			CottonResources.LOGGER.info("RELOADED Map: " + loading.generators);
+
 			return loading;
 		} catch (IOException | SyntaxError e) {
 			e.printStackTrace();
 		}
-		
+
 		return new CottonResourcesConfig();
 	}
 
 	public static void saveConfig(CottonResourcesConfig config) {
-		File file = new File(FabricLoader.getInstance().getConfigDirectory(),"CottonResources.json5");
-		
+		File file = new File(FabricLoader.getInstance().getConfigDirectory(), "CottonResources.json5");
+
 		Jankson jankson = JanksonFactory.builder()
-				.registerSerializer(BiomeSpec.class, (spec, marshaller)->TaggableSpec.serialize(spec))
-				.registerSerializer(DimensionSpec.class, (spec, marshaller)->TaggableSpec.serialize(spec))
-				.build();
-		
+			.registerSerializer(BiomeSpec.class, (spec, marshaller) -> TaggableSpec.serialize(spec))
+			.registerSerializer(DimensionSpec.class, (spec, marshaller) -> TaggableSpec.serialize(spec))
+			.build();
+
 		JsonElement json = jankson.toJson(config);
-		
+
 		try (FileOutputStream out = new FileOutputStream(file, false)) {
 			out.write(json.toJson(JsonGrammar.JSON5).getBytes(StandardCharsets.UTF_8));
 		} catch (IOException ex) {
 			LOGGER.error("Could not write config", ex);
 		}
 	}
-	
+
 	@SafeVarargs
 	public static <T> T[] mergeArrays(T[] a, T... b) {
-		T[] result = Arrays.copyOf(a, a.length+b.length);
+		T[] result = Arrays.copyOf(a, a.length + b.length);
 		System.arraycopy(b, 0, result, a.length, b.length);
 		return result;
 	}

--- a/src/main/java/io/github/cottonmc/resources/GlowingLayeredOreBlock.java
+++ b/src/main/java/io/github/cottonmc/resources/GlowingLayeredOreBlock.java
@@ -1,0 +1,66 @@
+package io.github.cottonmc.resources;
+
+import java.util.Random;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class GlowingLayeredOreBlock extends LayeredOreBlock {
+    public static final BooleanProperty LIT = Properties.LIT;
+
+    public GlowingLayeredOreBlock(Settings settings) {
+        super(settings);
+        this.setDefaultState(getStateManager().getDefaultState().with(LIT, false));
+    }
+
+    public int getLuminance(BlockState state) {
+        return state.get(LIT) ? super.getLuminance(state) : 0;
+    }
+
+    public void onBlockBreakStart(BlockState state, World world, BlockPos pos, PlayerEntity player) {
+        light(state, world, pos);
+        super.onBlockBreakStart(state, world, pos, player);
+    }
+
+    public void onSteppedOn(World world, BlockPos pos, Entity entity) {
+        light(world.getBlockState(pos), world, pos);
+        super.onSteppedOn(world, pos, entity);
+    }
+
+    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+        if (world.isClient) {
+            return ActionResult.SUCCESS;
+        } else {
+            light(state, world, pos);
+            return ActionResult.PASS;
+        }
+    }
+
+    private static void light(BlockState state, World world, BlockPos pos) {
+        if (!state.get(LIT)) {
+            world.setBlockState(pos, state.with(LIT, true), 3);
+        }
+
+    }
+
+    public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+        if (state.get(LIT)) {
+            world.setBlockState(pos, state.with(LIT, false), 3);
+        }
+
+    }
+
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        builder.add(LIT);
+    }
+}

--- a/src/main/java/io/github/cottonmc/resources/LayeredOreBlock.java
+++ b/src/main/java/io/github/cottonmc/resources/LayeredOreBlock.java
@@ -1,21 +1,21 @@
 package io.github.cottonmc.resources;
 
-import java.util.Collections;
-import java.util.List;
-
 import net.fabricmc.fabric.api.loot.v1.FabricLootSupplier;
-import net.minecraft.block.BlockRenderLayer;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.OreBlock;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.LootTables;
+import net.minecraft.loot.context.LootContext;
+import net.minecraft.loot.context.LootContextParameters;
+import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
-import net.minecraft.world.loot.LootPool;
-import net.minecraft.world.loot.LootSupplier;
-import net.minecraft.world.loot.LootTables;
-import net.minecraft.world.loot.context.LootContext;
-import net.minecraft.world.loot.context.LootContextParameters;
-import net.minecraft.world.loot.context.LootContextTypes;
+
+import java.util.Collections;
+import java.util.List;
 
 public class LayeredOreBlock extends OreBlock {
 
@@ -23,11 +23,6 @@ public class LayeredOreBlock extends OreBlock {
 	
 	public LayeredOreBlock(Settings settings) {
 		super(settings);
-	}
-
-	@Override
-	public BlockRenderLayer getRenderLayer() {
-		return BlockRenderLayer.CUTOUT_MIPPED;
 	}
 
 	@Override
@@ -40,7 +35,7 @@ public class LayeredOreBlock extends OreBlock {
 		} else {
 			LootContext context = builder.put(LootContextParameters.BLOCK_STATE, state).build(LootContextTypes.BLOCK);
 			ServerWorld world = context.getWorld();
-			LootSupplier lootSupplier = world.getServer().getLootManager().getSupplier(tableId);
+			LootTable lootSupplier = world.getServer().getLootManager().getSupplier(tableId);
 			
 			List<ItemStack> result = lootSupplier.getDrops(context);
 			if (result.isEmpty()) {
@@ -51,7 +46,7 @@ public class LayeredOreBlock extends OreBlock {
 					if (pools.isEmpty()) {
 						//Yup. Somehow we got a loot pool that just never drops anything.
 						if (!complainedAboutLoot) {
-							System.out.println("Loot pool '"+tableId+"' doesn't seem to be able to drop anything. Supplying the ore block instead. Please report this to the Cotton team!");
+							CottonResources.LOGGER.error("Loot pool '"+tableId+"' doesn't seem to be able to drop anything. Supplying the ore block instead. Please report this to the Cotton team!");
 							complainedAboutLoot = true;
 						}
 						result.add(new ItemStack(this.asItem()));

--- a/src/main/java/io/github/cottonmc/resources/ResourceTemplates.java
+++ b/src/main/java/io/github/cottonmc/resources/ResourceTemplates.java
@@ -1,0 +1,59 @@
+package io.github.cottonmc.resources;
+
+import io.github.cottonmc.resources.type.GemResourceType;
+import io.github.cottonmc.resources.type.MetalResourceType;
+import io.github.cottonmc.resources.type.RadioactiveResourceType;
+import io.github.cottonmc.resources.type.ResourceType;
+
+public final class ResourceTemplates {
+	/**
+	 * Creates a template MetalResourceType builder.
+	 * @param resourceName The name of the resource.
+	 * @return a new metal resource.
+	 */
+	public static MetalResourceType.Builder fullMetalType(String resourceName) {
+		return ResourceType.builder(resourceName)
+			.metal()
+			.allOres()
+			.withMachineAffixes()
+			.withItemAffixes();
+	}
+
+	/**
+	 * Creates a template MetalResourceType builder.
+	 * @param resourceName The name of the resource.
+	 * @return a new metal resource.
+	 */
+	public static MetalResourceType.Builder metalTypeNoOre(String resourceName) {
+		return ResourceType.builder(resourceName)
+			.metal()
+			.withMachineAffixes()
+			.withItemAffixes();
+	}
+
+	/**
+	 * Creates a template GemResourceType builder.
+	 * @param resourceName The name of the resource.
+	 * @return a new gem resource.
+	 */
+	public static GemResourceType.Builder fullGemType(String resourceName) {
+		return ResourceType.builder(resourceName)
+			.gem()
+			.allOres()
+			.withMachineAffixes()
+			.withDustAffix()
+			.withGemAffix();
+	}
+
+	/**
+	 * Creates a template RadioactiveResourceType along with ores.
+	 * @param resourceName The name of the resource.
+	 * @return a new gem resource.
+	 */
+	public static RadioactiveResourceType.Builder radioactiveTypeNoOre(String resourceName) {
+		return ResourceType.builder(resourceName)
+			.radioactive()
+			.withMachineAffixes()
+			.withItemAffixes();
+	}
+}

--- a/src/main/java/io/github/cottonmc/resources/command/StripCommand.java
+++ b/src/main/java/io/github/cottonmc/resources/command/StripCommand.java
@@ -27,26 +27,28 @@ public class StripCommand implements Command<ServerCommandSource>{
 	public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
 		ServerPlayerEntity caller = context.getSource().getPlayer();
 		Chunk chunk = caller.getEntityWorld().getChunk(caller.getBlockPos());
-		context.getSource().sendFeedback(new LiteralText("Stripping "+chunk.getPos()+"..."), true);
+		context.getSource().sendFeedback(new LiteralText("Stripping " + chunk.getPos() + "..."), true);
 		
-		Tag<Block> stripTag = BlockTags.getContainer().get(new Identifier("c:strip_command"));
-		if (stripTag==null) return -1;
+		Tag<Block> stripTag = BlockTags.getContainer().get(new Identifier("c", "strip_command"));
+		if (stripTag == null) {
+			return -1;
+		}
 		
-		for(int z=0; z<16; z++) {
-			for(int x=0; x<16; x++) {
-				for(int y=0; y<256; y++) {
+		for (int z = 0; z < 16; z++) {
+			for (int x = 0; x < 16; x++) {
+				for (int y = 0; y < 256; y++) {
 					BlockPos pos = chunk.getPos().toBlockPos(x, y, z);
 					BlockState toReplace = caller.getEntityWorld().getBlockState(pos);
-					if (toReplace.isAir()) continue;
-					
-					boolean strip = false;
-					if (stripTag!=null) {
-						strip = stripTag.contains(toReplace.getBlock());
-					} else {
-						strip = BUILTIN_STRIPS.contains(toReplace.getBlock());
+					if (toReplace.isAir()) {
+						continue;
 					}
 					
-					if (strip) caller.getEntityWorld().setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
+					boolean strip;
+					strip = stripTag.contains(toReplace.getBlock());
+
+					if (strip) {
+						caller.getEntityWorld().setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
+					}
 				}
 			}
 		}

--- a/src/main/java/io/github/cottonmc/resources/command/TagTestCommand.java
+++ b/src/main/java/io/github/cottonmc/resources/command/TagTestCommand.java
@@ -1,0 +1,42 @@
+package io.github.cottonmc.resources.command;
+
+import java.util.Map;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.github.cottonmc.resources.tag.DimensionTypeTags;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.tag.Tag;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.dimension.DimensionType;
+
+public class TagTestCommand {
+	public static int biomes(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+
+		return 1;
+	}
+
+	public static int dimensions(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		ServerCommandSource source = context.getSource();
+		Map<Identifier, Tag<DimensionType>> tags = DimensionTypeTags.getContainer().getEntries();
+
+		if (tags.isEmpty()) {
+			// TODO throw exception
+			return 0;
+		}
+
+		source.sendFeedback(new LiteralText("The following DimensionType tags exist:"), false);
+
+		for (Map.Entry<Identifier, Tag<DimensionType>> value : DimensionTypeTags.getContainer().getEntries().entrySet()) {
+			source.sendFeedback(new LiteralText(value.getKey().toString()), false);
+			source.sendFeedback(new LiteralText("Contains values:"), false);
+			Tag<DimensionType> tag = DimensionTypeTags.getContainer().get(value.getKey());
+
+			for (DimensionType dimensionType : tag.values()) {
+				source.sendFeedback(new LiteralText(DimensionType.getId(dimensionType).toString()), false);
+			}
+
+		}
+		return 1;
+	}
+}

--- a/src/main/java/io/github/cottonmc/resources/compat/REICompat.java
+++ b/src/main/java/io/github/cottonmc/resources/compat/REICompat.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import io.github.cottonmc.resources.CottonResources;
 import io.github.cottonmc.resources.oregen.OregenResourceListener;
 import io.github.cottonmc.resources.type.ResourceType;
-import me.shedaniel.rei.api.Entry;
+import me.shedaniel.rei.api.EntryStack;
 import me.shedaniel.rei.api.EntryRegistry;
 import me.shedaniel.rei.api.plugins.REIPluginV0;
 import net.fabricmc.loader.api.SemanticVersion;
@@ -32,36 +32,36 @@ public class REICompat implements REIPluginV0 {
 	@Override
 	public void registerEntries(EntryRegistry entryRegistry) {
 		CottonResources.LOGGER.info("Configuring resource visibility");
-		recheckItemHiding(entryRegistry.getModifiableEntryList());
+		recheckItemHiding(entryRegistry.getStacksList());
 	}
 	
-	public void recheckItemHiding(List<Entry> list) {
+	public void recheckItemHiding(List<EntryStack> list) {
 		for (ResourceType rsrc : CottonResources.BUILTINS.values()) {
 			if (IMMUNE_TO_HIDING.contains(rsrc.getBaseResource())) continue;
-			
-			System.out.println("Not hiding: "+OregenResourceListener.getConfig().ores);
+
+			CottonResources.LOGGER.info("Not hiding: "+OregenResourceListener.getConfig().ores);
 			boolean enabled = OregenResourceListener.getConfig().ores.contains(rsrc.getBaseResource());
 			for(String affix : rsrc.getAffixes()) {
 				Item item = rsrc.getItem(affix);
 				if (item==null || item.equals(Items.AIR)) {
-					System.out.println(rsrc.getBaseResource()+"_"+affix+" does not exist?!");
+					CottonResources.LOGGER.info(rsrc.getBaseResource()+"_"+affix+" does not exist?!");
 					continue;
 				}
 				ItemStack stack = new ItemStack(item);
 				
 				boolean add = enabled;
 				for(int i=0; i<list.size(); i++) {
-					Entry entry = list.get(i);
-					if (entry.getEntryType() == Entry.Type.ITEM) {
+					EntryStack entry = list.get(i);
+					if (entry.getType() == EntryStack.Type.ITEM) {
 						ItemStack listItem = entry.getItemStack();
 						if (listItem.getItem() == item) {
 							add = false;
 							if (!enabled) {
-								//System.out.println("Removing "+item.getTranslationKey());
+								//CottonResources.LOGGER.info("Removing "+item.getTranslationKey());
 								list.remove(i);
 								break;
 							} else {
-								//System.out.println("Letting stay "+item.getTranslationKey());
+								//CottonResources.LOGGER.info("Letting stay "+item.getTranslationKey());
 								break;
 							}
 						}
@@ -69,7 +69,7 @@ public class REICompat implements REIPluginV0 {
 				}
 				
 				//if (add) {
-					//System.out.println("Re-adding "+item.getTranslationKey());
+					//CottonResources.LOGGER.info("Re-adding "+item.getTranslationKey());
 				//	list.add(Entry.create(new ItemStack(item)));
 				//}
 			}

--- a/src/main/java/io/github/cottonmc/resources/mixin/MixinVanillaOregen.java
+++ b/src/main/java/io/github/cottonmc/resources/mixin/MixinVanillaOregen.java
@@ -8,26 +8,28 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+/**
+ * This Mixin exists solely for disabling vanilla ores.
+ */
 @Mixin(DefaultBiomeFeatures.class)
 public abstract class MixinVanillaOregen {
 
-
-    @Inject(method = "addDefaultOres", at = @At(value = "HEAD"))
-    private static void mixinDefaultOres(Biome biome_1, CallbackInfo ci) {
+    @Inject(method = "addDefaultOres", at = @At(value = "HEAD"), cancellable = true)
+    private static void mixinDefaultOres(Biome biome, CallbackInfo ci) {
         if (CottonResources.CONFIG.override_vanilla_generation) {
             ci.cancel();
         }
     }
 
-    @Inject(method = "addExtraGoldOre", at = @At(value = "HEAD"))
-    private static void mixinExtraGoldOre(Biome biome_1, CallbackInfo ci) {
+    @Inject(method = "addExtraGoldOre", at = @At(value = "HEAD"), cancellable = true)
+    private static void mixinExtraGoldOre(Biome biome, CallbackInfo ci) {
         if (CottonResources.CONFIG.override_vanilla_generation) {
             ci.cancel();
         }
     }
 
-    @Inject(method = "addEmeraldOre", at = @At(value = "HEAD"))
-    private static void mixinEmeraldOre(Biome biome_1, CallbackInfo ci) {
+    @Inject(method = "addEmeraldOre", at = @At(value = "HEAD"), cancellable = true)
+    private static void mixinEmeraldOre(Biome biome, CallbackInfo ci) {
         if (CottonResources.CONFIG.override_vanilla_generation) {
             ci.cancel();
         }

--- a/src/main/java/io/github/cottonmc/resources/oregen/DimensionSpec.java
+++ b/src/main/java/io/github/cottonmc/resources/oregen/DimensionSpec.java
@@ -3,11 +3,13 @@ package io.github.cottonmc.resources.oregen;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
 import blue.endless.jankson.JsonElement;
 import io.github.cottonmc.resources.tag.DimensionTypeTags;
 import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagContainer;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.dimension.Dimension;
@@ -40,12 +42,13 @@ public class DimensionSpec extends TaggableSpec<Dimension> {
 	}
 	
 	public static Set<Identifier> resolveTag(Identifier tagName) {
-		Tag<DimensionType> tag = DimensionTypeTags.CONTAINER.get(tagName);
+		TagContainer<DimensionType> tagContainer = DimensionTypeTags.getContainer();
+		Tag<DimensionType> tag = tagContainer.get(tagName);
 		if (tag==null) return ImmutableSet.of();
 		
 		HashSet<Identifier> result = new HashSet<>();
 		for(DimensionType dimension : tag.values()) {
-			Identifier id = Registry.DIMENSION.getId(dimension);
+			Identifier id = Registry.DIMENSION_TYPE.getId(dimension);
 			if (id!=null) result.add(id);
 		}
 		return result;

--- a/src/main/java/io/github/cottonmc/resources/oregen/OreGenerationSettings.java
+++ b/src/main/java/io/github/cottonmc/resources/oregen/OreGenerationSettings.java
@@ -1,5 +1,6 @@
 package io.github.cottonmc.resources.oregen;
 
+import com.google.common.base.MoreObjects;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
@@ -85,11 +86,11 @@ public class OreGenerationSettings {
 		
 		if (elem instanceof JsonPrimitive) {
 			BlockState state = BlockAndItemSerializers.getBlockStatePrimitive(((JsonPrimitive) elem).getValue());
-			if (state==null) System.out.println("State not found for "+((JsonPrimitive) elem).getValue());
+			if (state==null) CottonResources.LOGGER.error("State not found for "+((JsonPrimitive) elem).getValue());
 			return (state==null) ? ImmutableSet.of() : ImmutableSet.of(state);
 		} else if (elem instanceof JsonObject) {
 			BlockState state = BlockAndItemSerializers.getBlockState((JsonObject) elem);
-			if (state==null) System.out.println("State not found for "+((JsonPrimitive) elem).getValue());
+			if (state==null) CottonResources.LOGGER.error("State not found for "+((JsonPrimitive) elem).getValue());
 			return (state==null) ? ImmutableSet.of() : ImmutableSet.of(state);
 		} else if (elem instanceof JsonArray) {
 			HashSet<BlockState> result = new HashSet<>();
@@ -105,5 +106,16 @@ public class OreGenerationSettings {
 	public static int getIntOrDefault(JsonObject obj, String key, int defaultValue) {
 		Integer val = obj.get(Integer.class, key);
 		return (val==null) ? defaultValue : val;
+	}
+
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("min_height", min_height)
+				.add("max_height", max_height)
+				.add("cluster_size", cluster_size)
+				.add("cluster_count", cluster_count)
+				.add("dimensionspec", dimensions)
+				.add("biomes", biomes)
+				.toString();
 	}
 }

--- a/src/main/java/io/github/cottonmc/resources/oregen/OregenResourceListener.java
+++ b/src/main/java/io/github/cottonmc/resources/oregen/OregenResourceListener.java
@@ -63,7 +63,7 @@ public class OregenResourceListener implements SimpleSynchronousResourceReloadLi
 			String resourceName = replacerBlockEntry.getKey();
 			HashMap<String, String> replacements = replacerBlockEntry.getValue();
 			CottonResources.LOGGER.info("    Replacers for {}: {}", resourceName, replacements);
-			//System.out.println("    Replacers for "+resourceName+": "+replacements);
+			//CottonResources.LOGGER.info("    Replacers for "+resourceName+": "+replacements);
 		}*/
 		
 		REISafeCompat.doObjectHiding.run();

--- a/src/main/java/io/github/cottonmc/resources/oregen/TaggableSpec.java
+++ b/src/main/java/io/github/cottonmc/resources/oregen/TaggableSpec.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
 import blue.endless.jankson.JsonArray;
@@ -127,5 +128,13 @@ public abstract class TaggableSpec<T> implements Predicate<T> {
 		}
 		
 		return ImmutableSet.of();
+	}
+
+
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+			.add("Allowed", allow)
+			.add("Disallowed", deny)
+			.toString();
 	}
 }

--- a/src/main/java/io/github/cottonmc/resources/tag/DimensionTypeTags.java
+++ b/src/main/java/io/github/cottonmc/resources/tag/DimensionTypeTags.java
@@ -2,6 +2,9 @@ package io.github.cottonmc.resources.tag;
 
 import java.util.Optional;
 
+import net.minecraft.resource.ResourceReloadListener;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.ItemTags;
 import net.minecraft.tag.TagContainer;
 import net.minecraft.world.dimension.DimensionType;
 

--- a/src/main/java/io/github/cottonmc/resources/tag/WorldTagReloadListener.java
+++ b/src/main/java/io/github/cottonmc/resources/tag/WorldTagReloadListener.java
@@ -21,7 +21,7 @@ public class WorldTagReloadListener implements SimpleSynchronousResourceReloadLi
 		public void apply(ResourceManager resourceManager) {
 			BiomeTags.setContainer(reload(resourceManager, Registry.BIOME, "tags/biomes", "biome"));
 			
-			DimensionTypeTags.setContainer(reload(resourceManager, Registry.DIMENSION, "tags/dimensions", "dimension"));
+			DimensionTypeTags.setContainer(reload(resourceManager, Registry.DIMENSION_TYPE, "tags/dimensions", "dimension"));
 		}
 	//}
 	

--- a/src/main/java/io/github/cottonmc/resources/type/GemResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/type/GemResourceType.java
@@ -2,7 +2,11 @@ package io.github.cottonmc.resources.type;
 
 import io.github.cottonmc.resources.BlockSuppliers;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class GemResourceType extends GenericResourceType {
@@ -10,15 +14,75 @@ public class GemResourceType extends GenericResourceType {
 
     public GemResourceType(String name) {
         super(name);
-        withItemAffixes("", "dust");
-        withBlockAffix("block", BlockSuppliers.METAL_BLOCK);
     }
 
-    public GemResourceType withOreSupplier(Supplier<Block> oreSupplier) {
-        withBlockAffix("ore", oreSupplier);
-        withBlockAffix("nether_ore", oreSupplier);
-        withBlockAffix("end_ore", oreSupplier);
-        return this;
+    public Optional<Item> getGem() {
+        return Optional.ofNullable(this.getItem(""));
     }
 
+    public static class Builder extends ResourceTypeBuilder.Builder<GemResourceType.Builder> {
+        private boolean withGemAffix;
+
+        public Builder(String resourceName) {
+            super(resourceName);
+        }
+
+        @Override
+        public GemResourceType.Builder withItemAffixes() {
+            super.withItemAffixes();
+            this.withGemAffix = true;
+            return this;
+        }
+
+        public GemResourceType.Builder withGemAffix() {
+            this.withGemAffix = true;
+            return this;
+        }
+
+
+        public GemResourceType build() {
+            GemResourceType gem = new GemResourceType(this.resourceName);
+            List<String> affixes = new ArrayList<>();
+
+            if (this.withGemAffix) {
+                affixes.add("");
+            }
+
+            if (this.nuggetAffix) {
+                affixes.add("nugget");
+            }
+
+            if (this.dustAffix) {
+                affixes.add("dust");
+            }
+
+            if (this.gearAffix) {
+                affixes.add("gear");
+            }
+
+            if (this.plateAffix) {
+                affixes.add("plate");
+            }
+
+            gem.withItemAffixes(affixes.toArray(new String[0]));
+
+            if (!this.noBlock) {
+                gem.withBlockAffix("block", this.blockSupplier);
+            }
+
+            if (this.overworldOre) {
+                gem.withBlockAffix("ore", this.oreSupplier);
+            }
+
+            if (this.netherOre) {
+                gem.withBlockAffix("nether_ore", this.oreSupplier);
+            }
+
+            if (this.endOre) {
+                gem.withBlockAffix("end_ore", this.oreSupplier);
+            }
+
+            return gem;
+        }
+    }
 }

--- a/src/main/java/io/github/cottonmc/resources/type/GenericResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/type/GenericResourceType.java
@@ -1,17 +1,26 @@
 package io.github.cottonmc.resources.type;
 
 import io.github.cottonmc.resources.CottonResources;
+import io.github.cottonmc.resources.LayeredOreBlock;
 import io.github.cottonmc.resources.common.CommonRegistry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableSet;
@@ -65,13 +74,53 @@ public class GenericResourceType implements ResourceType {
 		return Registry.ITEM.getOrEmpty(id).orElse(null);
 	}
 
+	@Override
+	public Optional<Item> getGear() {
+		return Optional.ofNullable(this.getItem("gear"));
+	}
+
+	@Override
+	public Optional<Item> getDust() {
+		return Optional.ofNullable(this.getItem("dust"));
+	}
+
+	@Override
+	public Optional<Item> getNugget() {
+		return Optional.ofNullable(this.getItem("nugget"));
+	}
+
+	@Override
+	public Optional<Item> getPlate() {
+		return Optional.ofNullable(this.getItem("plate"));
+	}
+
+	@Override
+	public Optional<Block> getBlock() {
+		return Optional.ofNullable(this.getBlock("block"));
+	}
+
+	@Override
+	public Optional<Block> getOre() {
+		return Optional.ofNullable(this.getBlock("ore"));
+	}
+
+	@Override
+	public Optional<Block> getNetherOre() {
+		return Optional.ofNullable(this.getBlock("nether_ore"));
+	}
+
+	@Override
+	public Optional<Block> getEndOre() {
+		return Optional.ofNullable(this.getBlock("end_ore"));
+	}
+
 	public Item registerItem(String itemName) {
 		return CommonRegistry.register(itemName, new Item((new Item.Settings()).group(CottonResources.ITEM_GROUP)));
 	}
 
 	@Override
 	public Block getBlock(String blockName) {
-		Block existing = (blockName!=null) ? CommonRegistry.getBlock(name+"_"+blockName) : CommonRegistry.getBlock(name);
+		Block existing = (blockName != null) ? CommonRegistry.getBlock(name + "_"+blockName) : CommonRegistry.getBlock(name);
 		if (existing != null) {
 			return existing;
 		}
@@ -89,6 +138,11 @@ public class GenericResourceType implements ResourceType {
 		}
 
 		Block resultBlock = blockSupplier.get();
+
+		if (resultBlock instanceof LayeredOreBlock && FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT){
+			handleMipped(resultBlock);
+		}
+
 		BlockItem resultItem =  new BlockItem(resultBlock, new Item.Settings().group(CottonResources.ITEM_GROUP)); //Shouldn't be necessary, but is?
 
 		return CommonRegistry.register(blockName, resultBlock, resultItem);
@@ -113,6 +167,69 @@ public class GenericResourceType implements ResourceType {
 	public void registerItems() {
 		for (String affix : itemAffixes) {
 			registerItem(getFullNameForAffix(affix));
+		}
+	}
+
+	@Environment(EnvType.CLIENT)
+	private static void handleMipped(Block block) {
+		BlockRenderLayerMap.INSTANCE.putBlock(block, RenderLayer.getCutoutMipped());
+	}
+
+	public static class Builder extends ResourceTypeBuilder.Builder<GenericResourceType.Builder> {
+		private String affix;
+
+		public Builder(String resourceName) {
+			super(resourceName);
+		}
+
+		public GenericResourceType.Builder withAffix(String affix) {
+			this.affix = affix;
+			return this;
+		}
+
+		public GenericResourceType build() {
+			GenericResourceType generic = new GenericResourceType(this.resourceName);
+			List<String> affixes = new ArrayList<>();
+
+			if (this.affix != null) {
+				affixes.add(this.affix);
+			}
+
+			if (this.nuggetAffix) {
+				affixes.add("nugget");
+			}
+
+			if (this.dustAffix) {
+				affixes.add("dust");
+			}
+
+			if (this.gearAffix) {
+				affixes.add("gear");
+			}
+
+			if (this.plateAffix) {
+				affixes.add("plate");
+			}
+
+			generic.withItemAffixes(affixes.toArray(new String[0]));
+
+			if (!this.noBlock) {
+				generic.withBlockAffix("block", this.blockSupplier);
+			}
+
+			if (this.overworldOre) {
+				generic.withBlockAffix("ore", this.oreSupplier);
+			}
+
+			if (this.netherOre) {
+				generic.withBlockAffix("nether_ore", this.oreSupplier);
+			}
+
+			if (this.endOre) {
+				generic.withBlockAffix("end_ore", this.oreSupplier);
+			}
+
+			return generic;
 		}
 	}
 }

--- a/src/main/java/io/github/cottonmc/resources/type/MetalResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/type/MetalResourceType.java
@@ -2,7 +2,11 @@ package io.github.cottonmc.resources.type;
 
 import io.github.cottonmc.resources.BlockSuppliers;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class MetalResourceType extends GenericResourceType {
@@ -10,13 +14,89 @@ public class MetalResourceType extends GenericResourceType {
 
     public MetalResourceType(String name) {
         super(name);
-        withItemAffixes("ingot", "nugget", "dust");
-        withBlockAffix("block", BlockSuppliers.METAL_BLOCK);
     }
 
-    public MetalResourceType withOreSupplier(Supplier<Block> oreSupplier) {
-        withBlockAffix("ore", oreSupplier);
+    private MetalResourceType withOreSupplier(Supplier<Block> oreSupplier) {
+        this.oreSupplier = oreSupplier;
         return this;
+    }
+
+    public Optional<Item> getIngot() {
+        return Optional.ofNullable(this.getItem("ingot"));
+    }
+
+    public static MetalResourceType.Builder builder(String resourceName) {
+        return new Builder(resourceName);
+    }
+
+    public static class Builder extends ResourceTypeBuilder.Builder<MetalResourceType.Builder> {
+        private boolean withIngotAffix;
+
+        public Builder(String resourceName) {
+            super(resourceName);
+        }
+
+        @Override
+        public MetalResourceType.Builder withItemAffixes() {
+            super.withItemAffixes();
+            this.withIngotAffix = true;
+            return this;
+        }
+
+        public MetalResourceType.Builder withIngotAffix() {
+            this.withIngotAffix = true;
+            return this;
+        }
+
+        public MetalResourceType build() {
+            MetalResourceType metal = new MetalResourceType(this.resourceName);
+            List<String> affixes = new ArrayList<>();
+
+            if (this.withIngotAffix) {
+                affixes.add("ingot");
+            }
+
+            if (this.nuggetAffix) {
+                affixes.add("nugget");
+            }
+
+            if (this.dustAffix) {
+                affixes.add("dust");
+            }
+
+            if (this.gearAffix) {
+                affixes.add("gear");
+            }
+
+            if (this.plateAffix) {
+                affixes.add("plate");
+            }
+
+            metal.withItemAffixes(affixes.toArray(new String[0]));
+
+            if (!this.noBlock) {
+                metal.withBlockAffix("block", this.blockSupplier);
+            }
+
+            if (this.overworldOre || this.netherOre || this.endOre) {
+                metal.withOreSupplier(this.oreSupplier);
+            }
+
+            if (this.overworldOre) {
+                metal.withBlockAffix("ore", this.oreSupplier);
+            }
+
+            if (this.netherOre) {
+                metal.withBlockAffix("nether_ore", this.oreSupplier);
+            }
+
+            if (this.endOre) {
+                metal.withBlockAffix("end_ore", this.oreSupplier);
+            }
+
+            return metal;
+        }
+
     }
 
 }

--- a/src/main/java/io/github/cottonmc/resources/type/RadioactiveResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/type/RadioactiveResourceType.java
@@ -2,7 +2,11 @@ package io.github.cottonmc.resources.type;
 
 import io.github.cottonmc.resources.BlockSuppliers;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class RadioactiveResourceType extends GenericResourceType {
@@ -10,13 +14,80 @@ public class RadioactiveResourceType extends GenericResourceType {
 
     public RadioactiveResourceType(String name) {
         super(name);
-        withItemAffixes("dust");
-        withBlockAffix("block", BlockSuppliers.METAL_BLOCK);
+        //withItemAffixes("dust");
+        //withBlockAffix("block", BlockSuppliers.METAL_BLOCK);
     }
 
-    public RadioactiveResourceType withOreSupplier(Supplier<Block> oreSupplier) {
-        withBlockAffix("ore", oreSupplier);
+    public Optional<Item> getRadioactive() {
+        return Optional.ofNullable(this.getItem(""));
+    }
+
+    private RadioactiveResourceType withOreSupplier(Supplier<Block> oreSupplier) {
+        this.oreSupplier = oreSupplier;
         return this;
     }
 
+    public static class Builder extends ResourceTypeBuilder.Builder<RadioactiveResourceType.Builder> {
+        private String affix;
+
+        public Builder(String resourceName) {
+            super(resourceName);
+        }
+
+        public RadioactiveResourceType.Builder itemAffixName(String itemAffix) {
+            this.affix = itemAffix;
+            return this;
+        }
+
+        public RadioactiveResourceType build() {
+            RadioactiveResourceType radioactive = new RadioactiveResourceType(this.resourceName);
+            List<String> affixes = new ArrayList<>();
+
+            if (affix != null) {
+                affixes.add(affix);
+            } else {
+                affixes.add("");
+            }
+
+            if (this.nuggetAffix) {
+                affixes.add("nugget");
+            }
+
+            if (this.dustAffix) {
+                affixes.add("dust");
+            }
+
+            if (this.gearAffix) {
+                affixes.add("gear");
+            }
+
+            if (this.plateAffix) {
+                affixes.add("plate");
+            }
+
+            radioactive.withItemAffixes(affixes.toArray(new String[0]));
+
+            if (!this.noBlock) {
+                radioactive.withBlockAffix("block", this.blockSupplier);
+            }
+
+            if (this.overworldOre || this.netherOre || this.endOre) {
+                radioactive.withOreSupplier(this.oreSupplier);
+            }
+
+            if (this.overworldOre) {
+                radioactive.withBlockAffix("ore", this.oreSupplier);
+            }
+
+            if (this.netherOre) {
+                radioactive.withBlockAffix("nether_ore", this.oreSupplier);
+            }
+
+            if (this.endOre) {
+                radioactive.withBlockAffix("end_ore", this.oreSupplier);
+            }
+
+            return radioactive;
+        }
+    }
 }

--- a/src/main/java/io/github/cottonmc/resources/type/ResourceType.java
+++ b/src/main/java/io/github/cottonmc/resources/type/ResourceType.java
@@ -4,10 +4,15 @@ import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
 public interface ResourceType {
+	static ResourceTypeBuilder builder(String resourceName) {
+		return new ResourceTypeBuilder(resourceName);
+	}
+
 	/** Gets the base resource name. For example, "copper". */
 	String getBaseResource();
 
@@ -36,6 +41,22 @@ public interface ResourceType {
 	 */
 	@Nullable
 	Item getItem(String itemName);
+
+	Optional<Item> getGear();
+
+	Optional<Item> getDust();
+
+	Optional<Item> getNugget();
+
+	Optional<Item> getPlate();
+
+	Optional<Block> getBlock();
+
+	Optional<Block> getOre();
+
+	Optional<Block> getNetherOre();
+
+	Optional<Block> getEndOre();
 
 	/** 
 	 * Gets the block corresponding to this block name. If it's already defined, returns the already-defined one. If

--- a/src/main/java/io/github/cottonmc/resources/type/ResourceTypeBuilder.java
+++ b/src/main/java/io/github/cottonmc/resources/type/ResourceTypeBuilder.java
@@ -1,0 +1,124 @@
+package io.github.cottonmc.resources.type;
+
+import java.util.function.Supplier;
+import io.github.cottonmc.resources.BlockSuppliers;
+import net.minecraft.block.Block;
+
+public final class ResourceTypeBuilder {
+	private final String resourceName;
+
+	public ResourceTypeBuilder(String resourceName) {
+		this.resourceName = resourceName;
+	}
+
+	public MetalResourceType.Builder metal() {
+		return new MetalResourceType.Builder(resourceName);
+	}
+
+	public GemResourceType.Builder gem() {
+		return new GemResourceType.Builder(resourceName);
+	}
+
+	public RadioactiveResourceType.Builder radioactive() {
+		return new RadioactiveResourceType.Builder(resourceName);
+	}
+
+	public GenericResourceType.Builder generic() {
+		return new GenericResourceType.Builder(resourceName);
+	}
+
+	abstract static class Builder<B extends Builder<B>> {
+		protected final String resourceName;
+		// Ore related affixes
+		protected boolean overworldOre;
+		protected boolean endOre;
+		protected boolean netherOre;
+		// By default, assume this is a stone tier ore.
+		protected Supplier<Block> oreSupplier = BlockSuppliers.STONE_TIER_ORE;
+		protected Supplier<Block> blockSupplier = BlockSuppliers.METAL_BLOCK;
+		// Machine related affixes
+		protected boolean gearAffix;
+		protected boolean plateAffix;
+		// Item related affixes.
+		protected boolean dustAffix;
+		protected boolean nuggetAffix;
+
+		protected boolean noBlock;
+
+
+		public Builder(String resourceName) {
+			this.resourceName = resourceName;
+		}
+
+		public B allOres() {
+			this.overworldOre = true;
+			this.endOre = true;
+			this.netherOre = true;
+			return (B) this;
+		}
+
+		public B overworldOres() {
+			this.overworldOre = true;
+			return (B) this;
+		}
+
+		public B netherOres() {
+			this.netherOre = true;
+			return (B) this;
+		}
+
+		public B endOres() {
+			this.endOre = true;
+			return (B) this;
+		}
+
+		public B oreSupplier(Supplier<Block> oreSupplier) {
+			this.oreSupplier = oreSupplier;
+			return (B) this;
+		}
+
+		public B withMachineAffixes() {
+			this.gearAffix = true;
+			this.plateAffix = true;
+			return (B) this;
+		}
+
+		public B withGearAffix() {
+			this.gearAffix = true;
+			return (B) this;
+		}
+
+		public B withPlateAffix() {
+			this.plateAffix = true;
+			return (B) this;
+		}
+
+		public B withItemAffixes() {
+			this.dustAffix = true;
+			this.nuggetAffix = true;
+			// Ingots/Crystals are set within the specific resource types
+			return (B) this;
+		}
+
+		public B withDustAffix() {
+			this.dustAffix = true;
+			return (B) this;
+		}
+
+		public B withNuggetAffix() {
+			this.nuggetAffix = true;
+			return (B) this;
+		}
+
+		public B noBlock() {
+			this.noBlock = true;
+			return (B) this;
+		}
+
+		public B blockSupplier(Supplier<Block> supplier) {
+			this.blockSupplier = supplier;
+			return (B) this;
+		}
+
+	}
+}

--- a/src/main/resources/assets/c/models/block/ore.json
+++ b/src/main/resources/assets/c/models/block/ore.json
@@ -19,12 +19,12 @@
 			"from": [-0.05, -0.05, -0.05],
 			"to": [16.05, 16.05, 16.05],
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#ore"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#ore"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#ore"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#ore"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#ore"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#ore"}
+				"north": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "north"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "east"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "south"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "west"},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "up"},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#ore", "cullface": "down"}
 			}
 		}
 	]

--- a/src/main/resources/data/c/oregen/gems.json5
+++ b/src/main/resources/data/c/oregen/gems.json5
@@ -1,7 +1,7 @@
 {
 	"generators": {
 		"ruby": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { "tag": "c:overworlds" } ],
 
 			"ore_block": "c:ruby_ore",
 			
@@ -11,7 +11,7 @@
 			"cluster_size": 5
 		},
 		"topaz": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { "tag": "c:overworlds" } ],
 
 			"ore_block": "c:topaz_ore",
 			
@@ -21,7 +21,7 @@
 			"cluster_size": 5
 		},
 		"sapphire": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { tag: "c:overworlds"} ],
 
 			"ore_block": "c:sapphire_ore",
 			
@@ -31,7 +31,7 @@
 			"cluster_size": 5
 		},
 		"peridot": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { "tag": "c:overworlds" } ],
 
 			"ore_block": "c:peridot_ore",
 			
@@ -41,7 +41,7 @@
 			"cluster_size": 5
 		},
 		"amethyst": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { "tag": "c:overworlds" } ],
 
 			"ore_block": "c:amethyst_ore",
 			
@@ -54,22 +54,27 @@
 
 	"replacements": {
 		"ruby": {
+			"#c:natural_stone": "c:ruby_ore",
 			"minecraft:netherrack": "c:ruby_nether_ore",
 			"minecraft:end_stone": "c:ruby_end_ore"
 		},
 		"topaz": {
+			"#c:natural_stone": "c:topaz_ore",
 			"minecraft:netherrack": "c:topaz_nether_ore",
 			"minecraft:end_stone": "c:topaz_end_ore"
 		},
 		"amethyst": {
+			"#c:natural_stone": "c:amethyst_ore",
 			"minecraft:netherrack": "c:amethyst_nether_ore",
 			"minecraft:end_stone": "c:amethyst_end_ore"
 		},
 		"peridot": {
+			"#c:natural_stone": "c:peridot_ore",
 			"minecraft:netherrack": "c:peridot_nether_ore",
 			"minecraft:end_stone": "c:peridot_end_ore"
 		},
 		"sapphire": {
+			"#c:natural_stone": "c:sapphire_ore",
 			"minecraft:netherrack": "c:sapphire_nether_ore",
 			"minecraft:end_stone": "c:sapphire_end_ore"
 		},

--- a/src/main/resources/data/c/oregen/metals.json5
+++ b/src/main/resources/data/c/oregen/metals.json5
@@ -21,7 +21,7 @@
 		},
 
 		"copper": {
-			"dimensions": [ { "tag": "overworlds" } ],
+			"dimensions": [ { tag: "c:overworlds"} ],
 			"biomes": [ "*" ],
 
 			"ore_block": "c:copper_ore",
@@ -147,58 +147,72 @@
 	},
 	"replacements": {
 		"aluminum": {
+			"#c:natural_stone": "c:aluminum_ore",
 			"minecraft:netherrack": "c:aluminum_nether_ore",
 			"minecraft:end_stone": "c:aluminum_end_ore"
 		},
 		"cobalt": {
+			"#c:natural_stone": "c:cobalt_ore",
 			"minecraft:netherrack": "c:cobalt_nether_ore",
 			"minecraft:end_stone": "c:cobalt_end_ore"
 		},
 		"copper": {
+			"#c:natural_stone": "c:copper_ore",
 			"minecraft:netherrack": "c:copper_nether_ore",
 			"minecraft:end_stone": "c:copper_end_ore"
 		},
 		"iridium": {
+			"#c:natural_stone": "c:iridium_ore",
 			"minecraft:netherrack": "c:iridium_nether_ore",
 			"minecraft:end_stone": "c:iridium_end_ore"
 		},
 		"lead": {
+			"#c:natural_stone": "c:lead_ore",
 			"minecraft:netherrack": "c:lead_nether_ore",
 			"minecraft:end_stone": "c:lead_end_ore"
 		},
 		"osmium": {
+			"#c:natural_stone": "c:osmium_ore",
 			"minecraft:netherrack": "c:osmium_nether_ore",
 			"minecraft:end_stone": "c:osmium_end_ore"
 		},
 		"palladium": {
+			"#c:natural_stone": "c:palladium_ore",
 			"minecraft:netherrack": "c:palladium_nether_ore",
 			"minecraft:end_stone": "c:palladium_end_ore"
 		},
 		"platinum": {
+			"#c:natural_stone": "c:platinum_ore",
 			"minecraft:netherrack": "c:platinum_nether_ore",
 			"minecraft:end_stone": "c:platinum_end_ore"
 		},
 		"silver": {
+			"#c:natural_stone": "c:silver_ore",
 			"minecraft:netherrack": "c:silver_nether_ore",
 			"minecraft:end_stone": "c:silver_end_ore"
 		},
 		"tin": {
+			"#c:natural_stone": "c:tin_ore",
 			"minecraft:netherrack": "c:tin_nether_ore",
 			"minecraft:end_stone": "c:tin_end_ore"
 		},
 		"titanium": {
+			"#c:natural_stone": "c:titanium_ore",
 			"minecraft:netherrack": "c:titanium_nether_ore",
 			"minecraft:end_stone": "c:titanium_end_ore"
 		},
 		"tungsten": {
+			"#c:natural_stone": "c:tungsten_ore",
 			"minecraft:netherrack": "c:tungsten_nether_ore",
 			"minecraft:end_stone": "c:tungsten_end_ore"
 		},
 		"uranium": {
+			"#c:natural_stone": "c:uranium_ore",
 			"minecraft:netherrack": "c:uranium_nether_ore",
 			"minecraft:end_stone": "c:uranium_end_ore"
 		},
 		"zinc": {
+			"#c:natural_stone": "c:zinc_ore",
 			"minecraft:netherrack": "c:zinc_nether_ore",
 			"minecraft:end_stone": "c:zinc_end_ore"
 		},

--- a/src/main/resources/data/c/tags/blocks/aluminum_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/aluminum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_block",
+	"#c:aluminum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/aluminum_ores.json
+++ b/src/main/resources/data/c/tags/blocks/aluminum_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_ore",
+    "c:aluminum_nether_ore",
+    "c:aluminum_end_ore",
+	"#c:aluminum_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/amethyst_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/amethyst_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_block",
+	"#c:amethyst_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/amethyst_ores.json
+++ b/src/main/resources/data/c/tags/blocks/amethyst_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_ore",
+    "c:amethyst_nether_ore",
+    "c:amethyst_end_ore",
+	"#c:amethyst_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/brass_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/brass_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_block",
+	"#c:brass_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/coal_coke_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/coal_coke_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:coal_coke_block",
+	"#c:coal_coke_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/cobalt_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/cobalt_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_block",
+	"#c:cobalt_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/cobalt_ores.json
+++ b/src/main/resources/data/c/tags/blocks/cobalt_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_ore",
+    "c:cobalt_nether_ore",
+    "c:cobalt_end_ore",
+	"#c:cobalt_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/copper_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/copper_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_block",
+	"#c:copper_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/copper_ores.json
+++ b/src/main/resources/data/c/tags/blocks/copper_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_ore",
+    "c:copper_nether_ore",
+    "c:copper_end_ore",
+	"#c:copper_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/electrum_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/electrum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_block",
+	"#c:electrum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/iridium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/iridium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_block",
+	"#c:iridium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/iridium_ores.json
+++ b/src/main/resources/data/c/tags/blocks/iridium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_ore",
+    "c:iridium_nether_ore",
+    "c:iridium_end_ore",
+	"#c:iridium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/lead_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/lead_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_block",
+	"#c:lead_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/lead_ores.json
+++ b/src/main/resources/data/c/tags/blocks/lead_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_ore",
+    "c:lead_nether_ore",
+    "c:lead_end_ore",
+	"#c:lead_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/natural_stones.json
+++ b/src/main/resources/data/c/tags/blocks/natural_stones.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:stone",
+    "minecraft:andesite",
+    "minecraft:diorite",
+    "minecraft:granite"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/osmium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/osmium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_block",
+	"#c:osmium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/osmium_ores.json
+++ b/src/main/resources/data/c/tags/blocks/osmium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_ore",
+    "c:osmium_nether_ore",
+    "c:osmium_end_ore",
+	"#c:osmium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/palladium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/palladium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_block",
+	"#c:palladium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/palladium_ores.json
+++ b/src/main/resources/data/c/tags/blocks/palladium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_ore",
+    "c:palladium_nether_ore",
+    "c:palladium_end_ore",
+	"#c:palladium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/peridot_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/peridot_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_block",
+	"#c:peridot_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/peridot_ores.json
+++ b/src/main/resources/data/c/tags/blocks/peridot_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_ore",
+    "c:peridot_nether_ore",
+    "c:peridot_end_ore",
+	"#c:peridot_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/platinum_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/platinum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_block",
+	"#c:platinum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/platinum_ores.json
+++ b/src/main/resources/data/c/tags/blocks/platinum_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_ore",
+    "c:platinum_nether_ore",
+    "c:platinum_end_ore",
+	"#c:platinum_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/plutonium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/plutonium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_block",
+	"#c:plutonium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/ruby_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/ruby_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_block",
+	"#c:ruby_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/ruby_ores.json
+++ b/src/main/resources/data/c/tags/blocks/ruby_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_ore",
+    "c:ruby_nether_ore",
+    "c:ruby_end_ore",
+	"#c:ruby_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/sapphire_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/sapphire_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_block",
+	"#c:sapphire_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/sapphire_ores.json
+++ b/src/main/resources/data/c/tags/blocks/sapphire_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_ore",
+    "c:sapphire_nether_ore",
+    "c:sapphire_end_ore",
+	"#c:sapphire_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/silver_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/silver_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_block",
+	"#c:silver_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/silver_ores.json
+++ b/src/main/resources/data/c/tags/blocks/silver_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_ore",
+    "c:silver_nether_ore",
+    "c:silver_end_ore",
+	"#c:silver_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/steel_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/steel_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_block",
+	"#c:steel_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/strip_command.json
+++ b/src/main/resources/data/c/tags/blocks/strip_command.json
@@ -1,18 +1,20 @@
 {
   "replace": false,
   "values": [
-  	"minecraft:stone",
-  	"minecraft:granite",
-  	"minecraft:diorite",
-  	"minecraft:andesite",
-  	"minecraft:dirt",
-  	"minecraft:grass_block",
-  	"#minecraft:logs",
-  	"minecraft:water",
+	"minecraft:stone",
+	"minecraft:granite",
+	"minecraft:diorite",
+	"minecraft:andesite",
+	"minecraft:dirt",
+	"minecraft:gravel",
+	"minecraft:sand",
+	"minecraft:grass_block",
+	"#minecraft:logs",
+	"minecraft:water",
 
-  	"minecraft:netherrack",
-  	"minecraft:lava",
+	"minecraft:netherrack",
+	"minecraft:lava",
   	
-  	"minecraft:end_stone"
+	"minecraft:end_stone"
   ]
 }

--- a/src/main/resources/data/c/tags/blocks/thorium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/thorium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_block",
+	"#c:thorium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/tin_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/tin_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_block",
+	"#c:tin_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/tin_ores.json
+++ b/src/main/resources/data/c/tags/blocks/tin_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_ore",
+    "c:tin_nether_ore",
+    "c:tin_end_ore",
+	"#c:tin_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/titanium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/titanium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_block",
+	"#c:titanium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/titanium_ores.json
+++ b/src/main/resources/data/c/tags/blocks/titanium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_ore",
+    "c:titanium_nether_ore",
+    "c:titanium_end_ore",
+	"#c:titanium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/topaz_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/topaz_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_block",
+	"#c:topaz_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/topaz_ores.json
+++ b/src/main/resources/data/c/tags/blocks/topaz_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_ore",
+    "c:topaz_nether_ore",
+    "c:topaz_end_ore",
+	"#c:topaz_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/tungsten_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/tungsten_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_block",
+	"#c:tungsten_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/tungsten_ores.json
+++ b/src/main/resources/data/c/tags/blocks/tungsten_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_ore",
+    "c:tungsten_nether_ore",
+    "c:tungsten_end_ore",
+	"#c:tungsten_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/uranium_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/uranium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_block",
+	"#c:uranium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/uranium_ores.json
+++ b/src/main/resources/data/c/tags/blocks/uranium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_ore",
+    "c:uranium_nether_ore",
+    "c:uranium_end_ore",
+	"#c:uranium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/zinc_blocks.json
+++ b/src/main/resources/data/c/tags/blocks/zinc_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_block",
+	"#c:zinc_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/blocks/zinc_ores.json
+++ b/src/main/resources/data/c/tags/blocks/zinc_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_ore",
+    "c:zinc_nether_ore",
+    "c:zinc_end_ore",
+	"#c:zinc_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/dimensions/overworlds.json
+++ b/src/main/resources/data/c/tags/dimensions/overworlds.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "overworld"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_blocks.json
+++ b/src/main/resources/data/c/tags/items/aluminum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_block",
+    "#c:aluminum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_dusts.json
+++ b/src/main/resources/data/c/tags/items/aluminum_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_dust",
+    "#c:aluminum_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_gears.json
+++ b/src/main/resources/data/c/tags/items/aluminum_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_gear",
+    "#c:aluminum_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_ingots.json
+++ b/src/main/resources/data/c/tags/items/aluminum_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_ingot",
+    "#c:aluminum_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_nuggets.json
+++ b/src/main/resources/data/c/tags/items/aluminum_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_nugget",
+    "#c:aluminum_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_ores.json
+++ b/src/main/resources/data/c/tags/items/aluminum_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_ore",
+    "c:aluminum_nether_ore",
+    "c:aluminum_end_ore",
+    "#c:aluminum_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/aluminum_plates.json
+++ b/src/main/resources/data/c/tags/items/aluminum_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_plate",
+    "#c:aluminum_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethyst_blocks.json
+++ b/src/main/resources/data/c/tags/items/amethyst_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_block",
+    "#c:amethyst_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethyst_dusts.json
+++ b/src/main/resources/data/c/tags/items/amethyst_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_dust",
+    "#c:amethyst_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethyst_gears.json
+++ b/src/main/resources/data/c/tags/items/amethyst_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_gear",
+    "#c:amethyst_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethyst_ores.json
+++ b/src/main/resources/data/c/tags/items/amethyst_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_ore",
+    "c:amethyst_nether_ore",
+    "c:amethyst_end_ore",
+    "#c:amethyst_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethyst_plates.json
+++ b/src/main/resources/data/c/tags/items/amethyst_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst_plate",
+    "#c:amethyst_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/amethysts.json
+++ b/src/main/resources/data/c/tags/items/amethysts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:amethyst",
+    "#c:amethyst"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_blocks.json
+++ b/src/main/resources/data/c/tags/items/brass_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_block",
+    "#c:brass_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_dusts.json
+++ b/src/main/resources/data/c/tags/items/brass_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_dust",
+    "#c:brass_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_gears.json
+++ b/src/main/resources/data/c/tags/items/brass_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_gear",
+    "#c:brass_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_ingots.json
+++ b/src/main/resources/data/c/tags/items/brass_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_ingot",
+    "#c:brass_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_nuggets.json
+++ b/src/main/resources/data/c/tags/items/brass_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_nugget",
+    "#c:brass_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/brass_plates.json
+++ b/src/main/resources/data/c/tags/items/brass_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:brass_plate",
+    "#c:brass_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/coal_coke_blocks.json
+++ b/src/main/resources/data/c/tags/items/coal_coke_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:coal_coke_block",
+    "#c:coal_coke_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/coal_cokes.json
+++ b/src/main/resources/data/c/tags/items/coal_cokes.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:coal_coke",
+    "#c:coal_coke"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_blocks.json
+++ b/src/main/resources/data/c/tags/items/cobalt_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_block",
+    "#c:cobalt_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_dusts.json
+++ b/src/main/resources/data/c/tags/items/cobalt_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_dust",
+    "#c:cobalt_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_gears.json
+++ b/src/main/resources/data/c/tags/items/cobalt_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_gear",
+    "#c:cobalt_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_ingots.json
+++ b/src/main/resources/data/c/tags/items/cobalt_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_ingot",
+    "#c:cobalt_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_nuggets.json
+++ b/src/main/resources/data/c/tags/items/cobalt_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_nugget",
+    "#c:cobalt_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_ores.json
+++ b/src/main/resources/data/c/tags/items/cobalt_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_ore",
+    "c:cobalt_nether_ore",
+    "c:cobalt_end_ore",
+    "#c:cobalt_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/cobalt_plates.json
+++ b/src/main/resources/data/c/tags/items/cobalt_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:cobalt_plate",
+    "#c:cobalt_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_blocks.json
+++ b/src/main/resources/data/c/tags/items/copper_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_block",
+    "#c:copper_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_dusts.json
+++ b/src/main/resources/data/c/tags/items/copper_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_dust",
+    "#c:copper_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_gears.json
+++ b/src/main/resources/data/c/tags/items/copper_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_gear",
+    "#c:copper_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_ingots.json
+++ b/src/main/resources/data/c/tags/items/copper_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_ingot",
+    "#c:copper_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_nuggets.json
+++ b/src/main/resources/data/c/tags/items/copper_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_nugget",
+    "#c:copper_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_ores.json
+++ b/src/main/resources/data/c/tags/items/copper_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_ore",
+    "c:copper_nether_ore",
+    "c:copper_end_ore",
+    "#c:copper_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/copper_plates.json
+++ b/src/main/resources/data/c/tags/items/copper_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:copper_plate",
+    "#c:copper_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/diamond_dusts.json
+++ b/src/main/resources/data/c/tags/items/diamond_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:diamond_dust",
+    "#c:diamond_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/diamond_gears.json
+++ b/src/main/resources/data/c/tags/items/diamond_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:diamond_gear",
+    "#c:diamond_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/diamond_plates.json
+++ b/src/main/resources/data/c/tags/items/diamond_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:diamond_plate",
+    "#c:diamond_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_blocks.json
+++ b/src/main/resources/data/c/tags/items/electrum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_block",
+    "#c:electrum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_dusts.json
+++ b/src/main/resources/data/c/tags/items/electrum_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_dust",
+    "#c:electrum_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_gears.json
+++ b/src/main/resources/data/c/tags/items/electrum_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_gear",
+    "#c:electrum_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_ingots.json
+++ b/src/main/resources/data/c/tags/items/electrum_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_ingot",
+    "#c:electrum_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_nuggets.json
+++ b/src/main/resources/data/c/tags/items/electrum_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_nugget",
+    "#c:electrum_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/electrum_plates.json
+++ b/src/main/resources/data/c/tags/items/electrum_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:electrum_plate",
+    "#c:electrum_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/emerald_dusts.json
+++ b/src/main/resources/data/c/tags/items/emerald_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:emerald_dust",
+    "#c:emerald_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/emerald_gears.json
+++ b/src/main/resources/data/c/tags/items/emerald_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:emerald_gear",
+    "#c:emerald_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/emerald_plates.json
+++ b/src/main/resources/data/c/tags/items/emerald_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:emerald_plate",
+    "#c:emerald_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/gold_dusts.json
+++ b/src/main/resources/data/c/tags/items/gold_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:gold_dust",
+    "#c:gold_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/gold_gears.json
+++ b/src/main/resources/data/c/tags/items/gold_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:gold_gear",
+    "#c:gold_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/gold_plates.json
+++ b/src/main/resources/data/c/tags/items/gold_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:gold_plate",
+    "#c:gold_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_blocks.json
+++ b/src/main/resources/data/c/tags/items/iridium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_block",
+    "#c:iridium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_dusts.json
+++ b/src/main/resources/data/c/tags/items/iridium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_dust",
+    "#c:iridium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_gears.json
+++ b/src/main/resources/data/c/tags/items/iridium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_gear",
+    "#c:iridium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_ingots.json
+++ b/src/main/resources/data/c/tags/items/iridium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_ingot",
+    "#c:iridium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/iridium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_nugget",
+    "#c:iridium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_ores.json
+++ b/src/main/resources/data/c/tags/items/iridium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_ore",
+    "c:iridium_nether_ore",
+    "c:iridium_end_ore",
+    "#c:iridium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iridium_plates.json
+++ b/src/main/resources/data/c/tags/items/iridium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iridium_plate",
+	"#c:iridium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iron_dusts.json
+++ b/src/main/resources/data/c/tags/items/iron_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iron_dust",
+    "#c:iron_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iron_gears.json
+++ b/src/main/resources/data/c/tags/items/iron_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iron_gear",
+    "#c:iron_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/iron_plates.json
+++ b/src/main/resources/data/c/tags/items/iron_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:iron_plate",
+    "#c:iron_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_blocks.json
+++ b/src/main/resources/data/c/tags/items/lead_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_block",
+    "#c:lead_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_dusts.json
+++ b/src/main/resources/data/c/tags/items/lead_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_dust",
+    "#c:lead_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_gears.json
+++ b/src/main/resources/data/c/tags/items/lead_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_gear",
+    "#c:lead_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_ingots.json
+++ b/src/main/resources/data/c/tags/items/lead_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_ingot",
+    "#c:lead_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_nuggets.json
+++ b/src/main/resources/data/c/tags/items/lead_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_nugget",
+    "#c:lead_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_ores.json
+++ b/src/main/resources/data/c/tags/items/lead_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_ore",
+    "c:lead_nether_ore",
+    "c:lead_end_ore",
+    "#c:lead_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/lead_plates.json
+++ b/src/main/resources/data/c/tags/items/lead_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:lead_plate",
+    "#c:lead_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_blocks.json
+++ b/src/main/resources/data/c/tags/items/osmium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_block",
+    "#c:osmium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_dusts.json
+++ b/src/main/resources/data/c/tags/items/osmium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_dust",
+    "#c:osmium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_gears.json
+++ b/src/main/resources/data/c/tags/items/osmium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_gear",
+    "#c:osmium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_ingots.json
+++ b/src/main/resources/data/c/tags/items/osmium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_ingot",
+    "#c:osmium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/osmium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_nugget",
+    "#c:osmium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_ores.json
+++ b/src/main/resources/data/c/tags/items/osmium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_ore",
+    "c:osmium_nether_ore",
+    "c:osmium_end_ore",
+    "#c:osmium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/osmium_plates.json
+++ b/src/main/resources/data/c/tags/items/osmium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:osmium_plate",
+    "#c:osmium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_blocks.json
+++ b/src/main/resources/data/c/tags/items/palladium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_block",
+	"#c:palladium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_dusts.json
+++ b/src/main/resources/data/c/tags/items/palladium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_dust",
+    "#c:palladium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_gears.json
+++ b/src/main/resources/data/c/tags/items/palladium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_gear",
+    "#c:palladium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_ingots.json
+++ b/src/main/resources/data/c/tags/items/palladium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_ingot",
+    "#c:palladium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/palladium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_nugget",
+    "#c:palladium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_ores.json
+++ b/src/main/resources/data/c/tags/items/palladium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_ore",
+    "c:palladium_nether_ore",
+    "c:palladium_end_ore",
+    "#c:palladium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/palladium_plates.json
+++ b/src/main/resources/data/c/tags/items/palladium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:palladium_plate",
+    "#c:palladium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridot_blocks.json
+++ b/src/main/resources/data/c/tags/items/peridot_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_block",
+    "#c:peridot_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridot_dusts.json
+++ b/src/main/resources/data/c/tags/items/peridot_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_dust",
+    "#c:peridot_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridot_gears.json
+++ b/src/main/resources/data/c/tags/items/peridot_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_gear",
+    "#c:peridot_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridot_ores.json
+++ b/src/main/resources/data/c/tags/items/peridot_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_ore",
+    "c:peridot_nether_ore",
+    "c:peridot_end_ore",
+    "#c:peridot_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridot_plates.json
+++ b/src/main/resources/data/c/tags/items/peridot_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot_plate",
+    "#c:peridot_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/peridots.json
+++ b/src/main/resources/data/c/tags/items/peridots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:peridot",
+    "#c:peridot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_blocks.json
+++ b/src/main/resources/data/c/tags/items/platinum_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_block",
+    "#c:platinum_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_dusts.json
+++ b/src/main/resources/data/c/tags/items/platinum_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_dust",
+    "#c:platinum_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_gears.json
+++ b/src/main/resources/data/c/tags/items/platinum_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_gear",
+    "#c:platinum_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_ingots.json
+++ b/src/main/resources/data/c/tags/items/platinum_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_ingot",
+    "#c:platinum_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_nuggets.json
+++ b/src/main/resources/data/c/tags/items/platinum_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_nugget",
+    "#c:platinum_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_ores.json
+++ b/src/main/resources/data/c/tags/items/platinum_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_ore",
+    "c:platinum_nether_ore",
+    "c:platinum_end_ore",
+    "#c:platinum_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/platinum_plates.json
+++ b/src/main/resources/data/c/tags/items/platinum_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:platinum_plate",
+    "#c:platinum_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_blocks.json
+++ b/src/main/resources/data/c/tags/items/plutonium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_block",
+    "#c:plutonium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_dusts.json
+++ b/src/main/resources/data/c/tags/items/plutonium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_dust",
+    "#c:plutonium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_gears.json
+++ b/src/main/resources/data/c/tags/items/plutonium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_gear",
+    "#c:plutonium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_ingots.json
+++ b/src/main/resources/data/c/tags/items/plutonium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_ingot",
+    "#c:plutonium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/plutonium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_nugget",
+    "#c:plutonium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/plutonium_plates.json
+++ b/src/main/resources/data/c/tags/items/plutonium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:plutonium_plate",
+    "#c:plutonium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/rubies.json
+++ b/src/main/resources/data/c/tags/items/rubies.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby",
+    "#c:ruby"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/ruby_blocks.json
+++ b/src/main/resources/data/c/tags/items/ruby_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_block",
+    "#c:ruby_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/ruby_dusts.json
+++ b/src/main/resources/data/c/tags/items/ruby_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_dust",
+    "#c:ruby_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/ruby_gears.json
+++ b/src/main/resources/data/c/tags/items/ruby_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_gear",
+    "#c:ruby_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/ruby_ores.json
+++ b/src/main/resources/data/c/tags/items/ruby_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_ore",
+    "c:ruby_nether_ore",
+    "c:ruby_end_ore",
+	"#c:ruby_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/ruby_plates.json
+++ b/src/main/resources/data/c/tags/items/ruby_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:ruby_plate",
+    "#c:ruby_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphire_blocks.json
+++ b/src/main/resources/data/c/tags/items/sapphire_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_block",
+    "#c:sapphire_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphire_dusts.json
+++ b/src/main/resources/data/c/tags/items/sapphire_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_dust",
+    "#c:sapphire_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphire_gears.json
+++ b/src/main/resources/data/c/tags/items/sapphire_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_gear",
+    "#c:sapphire_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphire_ores.json
+++ b/src/main/resources/data/c/tags/items/sapphire_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_ore",
+    "c:sapphire_nether_ore",
+    "c:sapphire_end_ore",
+    "#c:sapphire_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphire_plates.json
+++ b/src/main/resources/data/c/tags/items/sapphire_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire_plate",
+    "#c:sapphire_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/sapphires.json
+++ b/src/main/resources/data/c/tags/items/sapphires.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:sapphire",
+    "#c:sapphire"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_blocks.json
+++ b/src/main/resources/data/c/tags/items/silver_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_block",
+    "#c:silver_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_dusts.json
+++ b/src/main/resources/data/c/tags/items/silver_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_dust",
+    "#c:silver_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_gears.json
+++ b/src/main/resources/data/c/tags/items/silver_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_gear",
+    "#c:silver_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_ingots.json
+++ b/src/main/resources/data/c/tags/items/silver_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_ingot",
+    "#c:silver_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_nuggets.json
+++ b/src/main/resources/data/c/tags/items/silver_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_nugget",
+    "#c:silver_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_ores.json
+++ b/src/main/resources/data/c/tags/items/silver_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_ore",
+    "c:silver_nether_ore",
+    "c:silver_end_ore",
+    "#c:silver_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/silver_plates.json
+++ b/src/main/resources/data/c/tags/items/silver_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:silver_plate",
+    "#c:silver_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_blocks.json
+++ b/src/main/resources/data/c/tags/items/steel_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_block",
+    "#c:steel_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_dusts.json
+++ b/src/main/resources/data/c/tags/items/steel_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_dust",
+    "#c:steel_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_gears.json
+++ b/src/main/resources/data/c/tags/items/steel_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_gear",
+    "#c:steel_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_ingots.json
+++ b/src/main/resources/data/c/tags/items/steel_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_ingot",
+	"#c:steel_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_nuggets.json
+++ b/src/main/resources/data/c/tags/items/steel_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_nugget",
+    "#c:steel_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/steel_plates.json
+++ b/src/main/resources/data/c/tags/items/steel_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:steel_plate",
+    "#c:steel_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/stone_gears.json
+++ b/src/main/resources/data/c/tags/items/stone_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:stone_gear",
+    "#c:stone_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_blocks.json
+++ b/src/main/resources/data/c/tags/items/thorium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_block",
+    "#c:thorium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_dusts.json
+++ b/src/main/resources/data/c/tags/items/thorium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_dust",
+    "#c:thorium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_gears.json
+++ b/src/main/resources/data/c/tags/items/thorium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_gear",
+    "#c:thorium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_ingots.json
+++ b/src/main/resources/data/c/tags/items/thorium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_ingot",
+	"#c:thorium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/thorium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_nugget",
+	"#c:thorium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/thorium_plates.json
+++ b/src/main/resources/data/c/tags/items/thorium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:thorium_plate",
+	"#c:thorium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_blocks.json
+++ b/src/main/resources/data/c/tags/items/tin_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_block",
+    "#c:tin_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_dusts.json
+++ b/src/main/resources/data/c/tags/items/tin_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_dust",
+    "#c:tin_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_gears.json
+++ b/src/main/resources/data/c/tags/items/tin_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_gear",
+    "#c:tin_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_ingots.json
+++ b/src/main/resources/data/c/tags/items/tin_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_ingot",
+    "#c:tin_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_nuggets.json
+++ b/src/main/resources/data/c/tags/items/tin_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_nugget",
+	"#c:tin_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_ores.json
+++ b/src/main/resources/data/c/tags/items/tin_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_ore",
+    "c:tin_nether_ore",
+    "c:tin_end_ore",
+    "#c:tin_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tin_plates.json
+++ b/src/main/resources/data/c/tags/items/tin_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tin_plate",
+    "#c:tin_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_blocks.json
+++ b/src/main/resources/data/c/tags/items/titanium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_block",
+    "#c:titanium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_dusts.json
+++ b/src/main/resources/data/c/tags/items/titanium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_dust",
+    "#c:titanium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_gears.json
+++ b/src/main/resources/data/c/tags/items/titanium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_gear",
+    "#c:titanium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_ingots.json
+++ b/src/main/resources/data/c/tags/items/titanium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_ingot",
+    "#c:titanium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/titanium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_nugget",
+    "#c:titanium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_ores.json
+++ b/src/main/resources/data/c/tags/items/titanium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_ore",
+    "c:titanium_nether_ore",
+    "c:titanium_end_ore",
+    "#c:titanium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/titanium_plates.json
+++ b/src/main/resources/data/c/tags/items/titanium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:titanium_plate",
+    "#c:titanium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topaz_blocks.json
+++ b/src/main/resources/data/c/tags/items/topaz_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_block",
+    "#c:topaz_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topaz_dusts.json
+++ b/src/main/resources/data/c/tags/items/topaz_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_dust",
+    "#c:topaz_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topaz_gears.json
+++ b/src/main/resources/data/c/tags/items/topaz_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_gear",
+    "#c:topaz_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topaz_ores.json
+++ b/src/main/resources/data/c/tags/items/topaz_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_ore",
+    "c:topaz_nether_ore",
+    "c:topaz_end_ore",
+    "#c:topaz_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topaz_plates.json
+++ b/src/main/resources/data/c/tags/items/topaz_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz_plate",
+    "#c:topaz_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/topazes.json
+++ b/src/main/resources/data/c/tags/items/topazes.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:topaz",
+    "#c:topaz"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_blocks.json
+++ b/src/main/resources/data/c/tags/items/tungsten_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_block",
+    "#c:tungsten_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_dusts.json
+++ b/src/main/resources/data/c/tags/items/tungsten_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_dust",
+    "#c:tungsten_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_gears.json
+++ b/src/main/resources/data/c/tags/items/tungsten_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_gear",
+    "#c:tungsten_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_ingots.json
+++ b/src/main/resources/data/c/tags/items/tungsten_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_ingot",
+    "#c:tungsten_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_nuggets.json
+++ b/src/main/resources/data/c/tags/items/tungsten_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_nugget",
+    "#c:tungsten_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_ores.json
+++ b/src/main/resources/data/c/tags/items/tungsten_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_ore",
+    "c:tungsten_nether_ore",
+    "c:tungsten_end_ore",
+    "#c:tungsten_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/tungsten_plates.json
+++ b/src/main/resources/data/c/tags/items/tungsten_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:tungsten_plate",
+    "#c:tungsten_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_blocks.json
+++ b/src/main/resources/data/c/tags/items/uranium_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_block",
+    "#c:uranium_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_dusts.json
+++ b/src/main/resources/data/c/tags/items/uranium_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_dust",
+    "#c:uranium_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_gears.json
+++ b/src/main/resources/data/c/tags/items/uranium_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_gear",
+    "#c:uranium_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_ingots.json
+++ b/src/main/resources/data/c/tags/items/uranium_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_ingot",
+    "#c:uranium_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_nuggets.json
+++ b/src/main/resources/data/c/tags/items/uranium_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_nugget",
+    "#c:uranium_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_ores.json
+++ b/src/main/resources/data/c/tags/items/uranium_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_ore",
+    "c:uranium_nether_ore",
+    "c:uranium_end_ore",
+    "#c:uranium_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/uranium_plates.json
+++ b/src/main/resources/data/c/tags/items/uranium_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:uranium_plate",
+    "#c:uranium_plate"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/wood_gears.json
+++ b/src/main/resources/data/c/tags/items/wood_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:wood_gear",
+	"#c:wood_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_blocks.json
+++ b/src/main/resources/data/c/tags/items/zinc_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_block",
+    "#c:zinc_block"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_dusts.json
+++ b/src/main/resources/data/c/tags/items/zinc_dusts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_dust",
+    "#c:zinc_dust"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_gears.json
+++ b/src/main/resources/data/c/tags/items/zinc_gears.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_gear",
+    "#c:zinc_gear"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_ingots.json
+++ b/src/main/resources/data/c/tags/items/zinc_ingots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_ingot",
+    "#c:zinc_ingot"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_nuggets.json
+++ b/src/main/resources/data/c/tags/items/zinc_nuggets.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_nugget",
+    "#c:zinc_nugget"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_ores.json
+++ b/src/main/resources/data/c/tags/items/zinc_ores.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_ore",
+    "c:zinc_nether_ore",
+    "c:zinc_end_ore",
+    "#c:zinc_ore"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/zinc_plates.json
+++ b/src/main/resources/data/c/tags/items/zinc_plates.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "c:zinc_plate",
+    "#c:zinc_plate"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/dragon_immune.json
+++ b/src/main/resources/data/minecraft/tags/blocks/dragon_immune.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "values": [
+    "c:aluminum_end_ore",
+    "c:amethyst_end_ore",
+    "c:cobalt_end_ore",
+    "c:copper_end_ore",
+    "c:iridium_end_ore",
+    "c:lead_end_ore",
+    "c:osmium_end_ore",
+    "c:palladium_end_ore",
+    "c:peridot_end_ore",
+    "c:platinum_end_ore",
+    "c:ruby_end_ore",
+    "c:sapphire_end_ore",
+    "c:silver_end_ore",
+    "c:tin_end_ore",
+    "c:titanium_end_ore",
+    "c:topaz_end_ore",
+    "c:tungsten_end_ore",
+    "c:uranium_end_ore",
+    "c:zinc_end_ore"
+  ]
+}


### PR DESCRIPTION
Fixes #46

Changes proposed in this pull request:
  - Converts LayeredOreBlocks to the new rendering system.
  - Why do all the ores light up at night? I don't know but only the uranium does that now and has a lit state.
  - World gen changes in how features are created were accounted for.

Note I also found an issue where if there was no replacer specified for any of the stone blocks, the overworld version of the ores would fail to actually generate.
